### PR TITLE
Windows build script improvements

### DIFF
--- a/build_sdk_windows_qt5_MSVC.bat
+++ b/build_sdk_windows_qt5_MSVC.bat
@@ -75,7 +75,7 @@ echo ************************************
 echo ***  Delete old build Directory  ***
 echo ************************************
 
-    rmdir /s /q build
+    rmdir /s /q build || rem
     if %ERRORLEVEL% NEQ 0 GOTO ERROR_HANDLER
 
 )
@@ -85,7 +85,7 @@ echo ***  Configure MSVC environment  ***
 echo ************************************
 
 call vcvarsall.bat %ARCHITECTURE%
-if %ERRORLEVEL% NEQ 0 goto error
+if %ERRORLEVEL% NEQ 0 goto ERROR_HANDLER
 echo configuring was successful
 
 if exist %DLT_VIEWER_SDK_DIR% (
@@ -93,7 +93,7 @@ echo ************************************
 echo ***   Delete old SDK Directory   ***
 echo ************************************
 
-    rmdir /s /q %DLT_VIEWER_SDK_DIR%
+    rmdir /s /q %DLT_VIEWER_SDK_DIR% || rem
     if %ERRORLEVEL% NEQ 0 GOTO ERROR_HANDLER
 )
 

--- a/build_sdk_windows_qt5_MSVC.bat
+++ b/build_sdk_windows_qt5_MSVC.bat
@@ -289,8 +289,7 @@ GOTO QUIT
 echo ####################################
 echo ###       ERROR occured          ###
 echo ####################################
-set /p name= Continue
-exit 1
+exit /b 1
 
 
 :QUIT
@@ -298,5 +297,4 @@ echo ************************************
 echo ***       SUCCESS finish         ***
 echo ************************************
 echo SDK installed in: %DLT_VIEWER_SDK_DIR%
-set /p name= Continue
-exit 0
+exit /b 0

--- a/build_sdk_windows_qt5_MSVC_interactive.bat
+++ b/build_sdk_windows_qt5_MSVC_interactive.bat
@@ -1,0 +1,4 @@
+call build_sdk_windows_qt5_MSVC.bat
+SET RETCODE=%ERRORLEVEL%
+set /p name= Continue
+exit /b %RETCODE%


### PR DESCRIPTION
Apparently, there are problems setting the errorlevel
variable after rmdir was called and if errorlevel is
checked afterwards it will be always reported as 0,
although there were errors when deleting the directories/files.

Executing the "rem" command on error works around this
issue. For details see https://stackoverflow.com/a/11137825

Also, remove user prompts and exit only the current script
(exit /b) instead of the whole cmd process to let users call
this script from other scripts for automation purposes for
example.

Signed-off-by: Jens Schmer <jens.schmer@garmin.com>