### PR TITLE
Include_fix: Corrected all qdlt includes

### DIFF
--- a/qdlt/plugininterface.h
+++ b/qdlt/plugininterface.h
@@ -20,9 +20,14 @@
 #ifndef PLUGININTERFACE_H
 #define PLUGININTERFACE_H
 
+#include "qdltconnection.h"
+#include "qdltcontrol.h"
+#include "qdltfile.h"
+#include "qdltmessagedecoder.h"
+#include "qdltmsg.h"
+
 #include <QString>
 #include <QTableView>
-#include "qdlt.h"
 
 #define PLUGIN_INTERFACE_VERSION "1.0.1"
 

--- a/qdlt/qdlt.h
+++ b/qdlt/qdlt.h
@@ -22,25 +22,21 @@
 #ifndef QDLT_H
 #define QDLT_H
 
-#include <qdltbase.h>
+#include "qdltbase.h"
 
-#include <qdltargument.h>
-#include <qdltmsg.h>
-#include <qdltfilter.h>
-#include <qdltfilterlist.h>
-#include <qdltfilterindex.h>
-#include <qdltdefaultfilter.h>
-#include <qdltfile.h>
-#include <qdltcontrol.h>
-#include <qdltconnection.h>
-#include <qdltipconnection.h>
-#include <qdlttcpconnection.h>
-#include <qdltudpconnection.h>
-#include <qdltserialconnection.h>
-#include <qdltmessagedecoder.h>
-#include <qdltplugin.h>
-#include <qdltpluginmanager.h>
-#include <qdltoptmanager.h>
-#include <qdltsettingsmanager.h>
+#include "qdltargument.h"
+#include "qdltmsg.h"
+#include "qdltfilter.h"
+#include "qdltfilterlist.h"
+#include "qdltfilterindex.h"
+#include "qdltdefaultfilter.h"
+#include "qdltfile.h"
+#include "qdltcontrol.h"
+#include "qdltconnection.h"
+#include "qdltipconnection.h"
+#include "qdlttcpconnection.h"
+#include "qdltudpconnection.h"
+#include "qdltserialconnection.h"
+#include "qdltmessagedecoder.h"
 
 #endif // QDLT_H

--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltargument.h"
 
 extern "C"
 {

--- a/qdlt/qdltargument.h
+++ b/qdlt/qdltargument.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltargument.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */
@@ -31,6 +31,7 @@
 #include <QVariant>
 #include <time.h>
 
+#include "qdltbase.h"
 #include "export_rules.h"
 
 //! One argument of a DLT message.

--- a/qdlt/qdltbase.cpp
+++ b/qdlt/qdltbase.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltbase.h"
 
 extern "C"
 {

--- a/qdlt/qdltbase.h
+++ b/qdlt/qdltbase.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltbase.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */

--- a/qdlt/qdltconnection.cpp
+++ b/qdlt/qdltconnection.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltconnection.h"
 
 extern "C"
 {

--- a/qdlt/qdltconnection.h
+++ b/qdlt/qdltconnection.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltconnection.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */

--- a/qdlt/qdltcontrol.cpp
+++ b/qdlt/qdltcontrol.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltcontrol.h"
 
 extern "C"
 {

--- a/qdlt/qdltcontrol.h
+++ b/qdlt/qdltcontrol.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltcontrol.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */

--- a/qdlt/qdltdefaultfilter.cpp
+++ b/qdlt/qdltdefaultfilter.cpp
@@ -24,7 +24,7 @@
 #include <QDir>
 #include <QDirIterator>
 
-#include "qdlt.h"
+#include "qdltdefaultfilter.h"
 
 extern "C"
 {

--- a/qdlt/qdltdefaultfilter.h
+++ b/qdlt/qdltdefaultfilter.h
@@ -33,6 +33,8 @@
 #include <QXmlStreamWriter>
 
 #include "export_rules.h"
+#include "qdltfilterindex.h"
+#include "qdltfilterlist.h"
 
 
 class QDLT_EXPORT QDltDefaultFilter

--- a/qdlt/qdltfile.cpp
+++ b/qdlt/qdltfile.cpp
@@ -22,7 +22,7 @@
 #include <QFile>
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltfile.h"
 
 extern "C"
 {

--- a/qdlt/qdltfile.h
+++ b/qdlt/qdltfile.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltfile.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */
@@ -23,6 +23,10 @@
 #define QDLT_FILE_H
 
 #include "export_rules.h"
+#include "qdltfilter.h"
+#include "qdltfilterlist.h"
+#include "qdltmsg.h"
+
 #include <QObject>
 #include <QString>
 #include <QFile>

--- a/qdlt/qdltfilter.cpp
+++ b/qdlt/qdltfilter.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltfilter.h"
 
 extern "C"
 {

--- a/qdlt/qdltfilter.h
+++ b/qdlt/qdltfilter.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltfilter.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */
@@ -32,7 +32,9 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 #include <QRegularExpression>
+
 #include "export_rules.h"
+#include "qdltmsg.h"
 
 
 class QDLT_EXPORT QDltFilter

--- a/qdlt/qdltfilterindex.cpp
+++ b/qdlt/qdltfilterindex.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltfilterindex.h"
 
 extern "C"
 {

--- a/qdlt/qdltfilterindex.h
+++ b/qdlt/qdltfilterindex.h
@@ -31,6 +31,7 @@
 #include <time.h>
 
 #include "export_rules.h"
+#include "qdltfilterlist.h"
 
 class QDLT_EXPORT QDltFilterIndex
 {

--- a/qdlt/qdltfilterlist.cpp
+++ b/qdlt/qdltfilterlist.cpp
@@ -22,7 +22,7 @@
 #include <QtDebug>
 #include <QCryptographicHash>
 
-#include "qdlt.h"
+#include "qdltfilterlist.h"
 
 
 extern "C"

--- a/qdlt/qdltfilterlist.h
+++ b/qdlt/qdltfilterlist.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltfilterlist.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */
@@ -23,6 +23,9 @@
 #define QDLT_FILTER_LIST_H
 
 #include "export_rules.h"
+#include "qdltfilter.h"
+#include "qdltmsg.h"
+
 #include <QObject>
 #include <QString>
 #include <QFile>
@@ -34,6 +37,7 @@
 #include <time.h>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
+
 
 class QDLT_EXPORT QDltFilterList
 {

--- a/qdlt/qdltipconnection.cpp
+++ b/qdlt/qdltipconnection.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltipconnection.h"
 
 extern "C"
 {

--- a/qdlt/qdltmessagedecoder.h
+++ b/qdlt/qdltmessagedecoder.h
@@ -23,6 +23,7 @@
 #define QDLTMESSAGEDECODER_HPP
 
 #include "export_rules.h"
+#include "qdltmsg.h"
 
 class QDltMsg;
 

--- a/qdlt/qdltmsg.cpp
+++ b/qdlt/qdltmsg.cpp
@@ -21,7 +21,7 @@
 
 #include <QtDebug>
 
-#include "qdlt.h"
+#include "qdltmsg.h"
 
 extern "C"
 {

--- a/qdlt/qdltmsg.h
+++ b/qdlt/qdltmsg.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltmsg.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */
@@ -31,6 +31,8 @@
 #include <time.h>
 
 #include "export_rules.h"
+#include "qdltbase.h"
+#include "qdltargument.h"
 
 //! Access to a DLT message.
 /*!

--- a/qdlt/qdltplugin.cpp
+++ b/qdlt/qdltplugin.cpp
@@ -17,30 +17,6 @@ QDltPlugin::QDltPlugin()
     mode = ModeDisable;
 }
 
-QString QDltPlugin::getName()
-{
-    if(plugininterface)
-        return plugininterface->name();
-    else
-        return QString();
-}
-
-QString QDltPlugin::getPluginVersion()
-{
-    if(plugininterface)
-        return plugininterface->pluginVersion();
-    else
-        return QString();
-}
-
-QString QDltPlugin::getPluginInterfaceVersion()
-{
-    if(plugininterface)
-        return plugininterface->pluginInterfaceVersion();
-    else
-        return QString();
-}
-
 int QDltPlugin::getMode()
 {
     //return QDltSettingsManager::getInstance()->value("plugin/pluginmodefor"+getName(),QVariant(QDltPlugin::ModeDisable)).toInt();
@@ -99,15 +75,6 @@ void QDltPlugin::loadPlugin(QObject *plugin)
 
 }
 
-bool QDltPlugin::decodeMsg(QDltMsg &msg, int triggeredByUser)
-{
-    if(mode != ModeDisable && plugindecoderinterface && plugindecoderinterface->isMsg(msg,triggeredByUser))
-    {
-        return plugindecoderinterface->decodeMsg(msg,triggeredByUser);
-    }
-    return false;
-}
-
 bool QDltPlugin::isDecoder()
 {
     return (plugindecoderinterface?true:false);
@@ -128,20 +95,29 @@ bool QDltPlugin::isCommand()
     return (plugincommandinterface?true:false);
 }
 
-QStringList QDltPlugin::infoConfig()
+// generic plugin interfaces
+QString QDltPlugin::name()
 {
     if(plugininterface)
-        return plugininterface->infoConfig();
+        return plugininterface->name();
     else
-        return QStringList();
+        return QString();
 }
 
-bool QDltPlugin::loadConfig(QString filename)
+QString QDltPlugin::pluginVersion()
 {
     if(plugininterface)
-        return plugininterface->loadConfig(filename);
+        return plugininterface->pluginVersion();
     else
-        return false;
+        return QString();
+}
+
+QString QDltPlugin::pluginInterfaceVersion()
+{
+    if(plugininterface)
+        return plugininterface->pluginInterfaceVersion();
+    else
+        return QString();
 }
 
 QString QDltPlugin::error()
@@ -152,12 +128,20 @@ QString QDltPlugin::error()
         return QString();
 }
 
-bool QDltPlugin::command(QString cmd,QStringList params)
+bool QDltPlugin::loadConfig(QString filename)
 {
-    if(plugincommandinterface)
-        return plugincommandinterface->command(cmd,params);
+    if(plugininterface)
+        return plugininterface->loadConfig(filename);
     else
         return false;
+}
+
+QStringList QDltPlugin::infoConfig()
+{
+    if(plugininterface)
+        return plugininterface->infoConfig();
+    else
+        return QStringList();
 }
 
 // viewer plugin interfaces
@@ -173,11 +157,6 @@ void QDltPlugin::initFileStart(QDltFile *file)
 if(pluginviewerinterface)
     pluginviewerinterface->initFileStart(file);
 }
-void QDltPlugin::initFileFinish()
-{
-if(pluginviewerinterface)
-    pluginviewerinterface->initFileFinish();
-}
 void QDltPlugin::initMsg(int index, QDltMsg &msg)
 {
 if(pluginviewerinterface)
@@ -187,6 +166,11 @@ void QDltPlugin::initMsgDecoded(int index, QDltMsg &msg)
 {
 if(pluginviewerinterface)
     pluginviewerinterface->initMsgDecoded(index,msg);
+}
+void QDltPlugin::initFileFinish()
+{
+if(pluginviewerinterface)
+    pluginviewerinterface->initFileFinish();
 }
 void QDltPlugin::updateFileStart()
 {
@@ -217,24 +201,6 @@ void QDltPlugin::selectedIdxMsgDecoded(int index, QDltMsg &msg)
 {
 if(pluginviewerinterface)
     pluginviewerinterface->selectedIdxMsgDecoded(index,msg);
-}
-
-void QDltPlugin::initMessageDecoder(QDltMessageDecoder* messageDecoder)
-{
-if(plugincontrolinterface)
-    plugincontrolinterface->initMessageDecoder(messageDecoder);
-}
-
-void QDltPlugin::initMainTableView(QTableView* pTableView)
-{
-if(plugincontrolinterface)
-    plugincontrolinterface->initMainTableView(pTableView);
-}
-
-void QDltPlugin::configurationChanged()
-{
-if(plugincontrolinterface)
-    plugincontrolinterface->configurationChanged();
 }
 
 // control plugin interface
@@ -278,3 +244,39 @@ bool QDltPlugin::autoscrollStateChanged(bool enabled)
         return false;
 }
 
+void QDltPlugin::initMessageDecoder(QDltMessageDecoder* messageDecoder)
+{
+if(plugincontrolinterface)
+    plugincontrolinterface->initMessageDecoder(messageDecoder);
+}
+
+void QDltPlugin::initMainTableView(QTableView* pTableView)
+{
+if(plugincontrolinterface)
+    plugincontrolinterface->initMainTableView(pTableView);
+}
+
+void QDltPlugin::configurationChanged()
+{
+if(plugincontrolinterface)
+    plugincontrolinterface->configurationChanged();
+}
+
+// decoder plugin interfaces
+bool QDltPlugin::decodeMsg(QDltMsg &msg, int triggeredByUser)
+{
+    if(mode != ModeDisable && plugindecoderinterface && plugindecoderinterface->isMsg(msg,triggeredByUser))
+    {
+        return plugindecoderinterface->decodeMsg(msg,triggeredByUser);
+    }
+    return false;
+}
+
+// command plugin interfaces
+bool QDltPlugin::command(QString cmd,QList<QString> params)
+{
+    if(plugincommandinterface)
+        return plugincommandinterface->command(cmd,params);
+    else
+        return false;
+}

--- a/qdlt/qdltplugin.h
+++ b/qdlt/qdltplugin.h
@@ -7,12 +7,6 @@
 
 #include "export_rules.h"
 
-class QDLTPluginInterface;
-class QDLTPluginDecoderInterface;
-class QDltPluginViewerInterface;
-class QDltPluginControlInterface;
-class QDltPluginCommandInterface;
-class QTableView;
 
 //! Access class to a DLT Plugin to decode, view and control DLT messages
 /*!
@@ -34,15 +28,6 @@ public:
     //! Load the plugin by attaching the interfaces
     void loadPlugin(QObject *plugin);
 
-    //! Get the name of the plugin
-    QString getName();
-
-    //! Get the plugin version string
-    QString getPluginVersion();
-
-    //! Get the plugin interface version string
-    QString getPluginInterfaceVersion();
-
     //! Get the running status of the plugin
     /*!
       Plugin can be disabled, enabled and viewed.
@@ -60,12 +45,6 @@ public:
 
     //! Set the complete filename of the plugin including path and load the plugin configuration
     void setFilename(QString _filename);
-
-    //! Decode plugin if enabled and messages matches the decoder
-    /*!
-      \return True if decoded, false if not decoded
-    */
-    bool decodeMsg(QDltMsg &msg, int triggeredByUser);
 
     //! Check if this is a decoder plugin
     /*!
@@ -92,25 +71,25 @@ public:
     bool isCommand();
 
     // generic plugin interfaces
-    QStringList infoConfig();
+    QString name();
+    QString pluginVersion();
+    QString pluginInterfaceVersion();
     QString error();
     bool loadConfig(QString filename);
+    QStringList infoConfig();
 
     // viewer plugin interfaces
     QWidget* initViewer();
     void initFileStart(QDltFile *file);
-    void initFileFinish();
     void initMsg(int index, QDltMsg &msg);
     void initMsgDecoded(int index, QDltMsg &msg);
+    void initFileFinish();
     void updateFileStart();
     void updateMsg(int index, QDltMsg &msg);
     void updateMsgDecoded(int index, QDltMsg &msg);
     void updateFileFinish();
     void selectedIdxMsg(int index, QDltMsg &msg);
     void selectedIdxMsgDecoded(int index, QDltMsg &msg);
-    void initMessageDecoder(QDltMessageDecoder* messageDecoder);
-    void initMainTableView(QTableView* pTableView);
-    void configurationChanged();
 
     // control plugin interfaces
     bool initControl(QDltControl *control);
@@ -118,9 +97,15 @@ public:
     bool controlMsg(int index, QDltMsg &msg);
     bool stateChanged(int index, QDltConnection::QDltConnectionState connectionState, QString hostname);
     bool autoscrollStateChanged(bool enabled);
+    void initMessageDecoder(QDltMessageDecoder* messageDecoder);
+    void initMainTableView(QTableView* pTableView);
+    void configurationChanged();
+
+    // decoder plugin interfaces
+    bool decodeMsg(QDltMsg &msg, int triggeredByUser);
 
     // command plugin interfaces
-    bool command(QString cmd,QStringList params);
+    bool command(QString cmd,QList<QString> params);
 
 private:
 

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -1,4 +1,5 @@
 #include "qdltplugin.h"
+#include "qdltpluginmanager.h"
 
 #include <QDir>
 #include <QCoreApplication>
@@ -133,7 +134,7 @@ void QDltPluginManager::loadConfig(QString pluginName,QString filename)
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
-        if(plugin->getName()==pluginName)
+        if(plugin->name()==pluginName)
             plugin->setFilename(filename);
     }
 }
@@ -157,7 +158,7 @@ QDltPlugin* QDltPluginManager::findPlugin(QString &name)
     {
         QDltPlugin *plugin = plugins[num];
 
-        if(plugin->getName()==name)
+        if(plugin->name()==name)
             return plugin;
     }
     return 0;

--- a/qdlt/qdltsegmentedmsg.cpp
+++ b/qdlt/qdltsegmentedmsg.cpp
@@ -21,7 +21,6 @@
 
 #include <QByteArray>
 
-#include "qdlt.h"
 #include "qdltsegmentedmsg.h"
 
 

--- a/qdlt/qdltserialconnection.cpp
+++ b/qdlt/qdltserialconnection.cpp
@@ -20,9 +20,9 @@
  */
 
 #include <QtDebug>
-#include <QSerialPort>
 
-#include "qdlt.h"
+#include <QSerialPort>
+#include "qdltserialconnection.h"
 
 extern "C"
 {

--- a/qdlt/qdltserialconnection.h
+++ b/qdlt/qdltserialconnection.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdltserialconnection.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */
@@ -31,6 +31,7 @@
 #include <time.h>
 
 #include "export_rules.h"
+#include "qdltconnection.h"
 
 class QSerialPort;
 

--- a/qdlt/qdltsettingsmanager.cpp
+++ b/qdlt/qdltsettingsmanager.cpp
@@ -29,6 +29,8 @@
 
 #include "qdltsettingsmanager.h"
 
+#include <ctime>
+
 #if (WIN32)
  #define TZSET _tzset()
  #define TIMEZONE _timezone

--- a/qdlt/qdltsettingsmanager.cpp
+++ b/qdlt/qdltsettingsmanager.cpp
@@ -27,7 +27,7 @@
 
 #include "version.h"
 
-#include "qdlt.h"
+#include "qdltsettingsmanager.h"
 
 #if (WIN32)
  #define TZSET _tzset()

--- a/qdlt/qdlttcpconnection.cpp
+++ b/qdlt/qdlttcpconnection.cpp
@@ -22,7 +22,7 @@
 #include <QtDebug>
 #include <QTcpSocket>
 
-#include "qdlt.h"
+#include "qdlttcpconnection.h"
 
 extern "C"
 {

--- a/qdlt/qdlttcpconnection.h
+++ b/qdlt/qdlttcpconnection.h
@@ -14,7 +14,7 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  *
- * \file qdlt.h
+ * \file qdlttcpconnection.h
  * For further information see http://www.genivi.org/.
  * @licence end@
  */
@@ -31,6 +31,7 @@
 #include <time.h>
 
 #include "export_rules.h"
+#include "qdltipconnection.h"
 
 class QTcpSocket;
 

--- a/qdlt/qdltudpconnection.cpp
+++ b/qdlt/qdltudpconnection.cpp
@@ -22,7 +22,7 @@
 #include <QtDebug>
 #include <QUdpSocket>
 
-#include "qdlt.h"
+#include "qdltudpconnection.h"
 
 extern "C"
 {

--- a/qdlt/qdltudpconnection.h
+++ b/qdlt/qdltudpconnection.h
@@ -31,6 +31,7 @@
 #include <time.h>
 
 #include "export_rules.h"
+#include "qdltipconnection.h"
 
 class QUdpSocket;
 

--- a/src/dltexporter.cpp
+++ b/src/dltexporter.cpp
@@ -2,10 +2,11 @@
 #include <QMessageBox>
 #include <QApplication>
 #include <QClipboard>
+#include <QDebug>
 
 #include "dltexporter.h"
 #include "fieldnames.h"
-#include "project.h"
+#include "qdltoptmanager.h"
 
 DltExporter::DltExporter(QObject *parent) :
     QObject(parent)

--- a/src/dltexporter.h
+++ b/src/dltexporter.h
@@ -6,7 +6,9 @@
 #include <QModelIndexList>
 #include <QTreeWidget>
 
-#include "qdlt.h"
+#include "qdltfile.h"
+#include "qdltmsg.h"
+#include "qdltpluginmanager.h"
 
 class DltExporter : public QObject
 {

--- a/src/dltfileindexer.cpp
+++ b/src/dltfileindexer.cpp
@@ -9,6 +9,7 @@
 #include <QCryptographicHash>
 #include <QMutexLocker>
 
+#include "qdltoptmanager.h"
 
 extern "C" {
     #include "dlt_common.h"
@@ -817,8 +818,8 @@ QByteArray DltFileIndexer::md5ActiveDecoderPlugins()
     {
         QDltPlugin *plugin = activeDecoderPlugins[num];
 
-        hashString += plugin->getName();
-        hashString += plugin->getPluginVersion();
+        hashString += plugin->name();
+        hashString += plugin->pluginVersion();
         hashString += plugin->getFilename();
     }
     hashByteArray = hashString.toLatin1();

--- a/src/dltfileindexer.h
+++ b/src/dltfileindexer.h
@@ -8,7 +8,10 @@
 #include <QPair>
 #include <QMutex>
 
-#include "qdlt.h"
+#include "qdltdefaultfilter.h"
+#include "qdltfile.h"
+#include "qdltplugin.h"
+#include "qdltpluginmanager.h"
 
 #define DLT_FILE_INDEXER_SEG_SIZE (1024*1024)
 #define DLT_FILE_INDEXER_FILE_VERSION 2

--- a/src/dltfileutils.cpp
+++ b/src/dltfileutils.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #endif
 
+#include "qdltsettingsmanager.h"
 
 
 

--- a/src/dltfileutils.h
+++ b/src/dltfileutils.h
@@ -2,7 +2,6 @@
 #define DLTFILEUTILS_H
 
 #include <QDir>
-#include "settingsdialog.h"
 
 class DltFileUtils : QObject
 {

--- a/src/dltmsgqueue.h
+++ b/src/dltmsgqueue.h
@@ -3,7 +3,8 @@
 
 #include <QSemaphore>
 #include <QSharedPointer>
-#include "qdlt.h"
+
+#include "qdltmsg.h"
 
 class DltMsgQueue
 {

--- a/src/fieldnames.h
+++ b/src/fieldnames.h
@@ -1,7 +1,7 @@
 #ifndef FIELDNAMES_H
 #define FIELDNAMES_H
 
-#include "settingsdialog.h"
+#include "qdltsettingsmanager.h"
 #include <QObject>
 #include <QString>
 

--- a/src/filterdialog.h
+++ b/src/filterdialog.h
@@ -23,8 +23,6 @@
 #include <QDialog>
 #include <QColorDialog>
 #include <QAbstractButton>
-#include "project.h"
-#include "qdlt.h"
 
 namespace Ui {
     class FilterDialog;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 #include <QModelIndex>
 #include <QApplication>
 
-#include <qdlt.h>
+#include <qdltoptmanager.h>
 
 #include "mainwindow.h"
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -78,6 +78,7 @@ extern "C" {
 #include "jumptodialog.h"
 #include "fieldnames.h"
 #include "tablemodel.h"
+#include "qdltoptmanager.h"
 
 
 MainWindow::MainWindow(QWidget *parent) :
@@ -5711,8 +5712,8 @@ void MainWindow::loadPlugins()
 
       PluginItem* item = new PluginItem(0,plugin);
 
-      plugin->setMode((QDltPlugin::Mode) QDltSettingsManager::getInstance()->value("plugin/pluginmodefor"+plugin->getName(),QVariant(QDltPlugin::ModeDisable)).toInt());
-      qDebug() << "Loading plugin" << plugin->getName() << plugin->getPluginVersion();
+      plugin->setMode((QDltPlugin::Mode) QDltSettingsManager::getInstance()->value("plugin/pluginmodefor"+plugin->name(),QVariant(QDltPlugin::ModeDisable)).toInt());
+      qDebug() << "Loading plugin" << plugin->name() << plugin->pluginVersion();
       if(plugin->isViewer())
       {
         item->widget = plugin->initViewer();
@@ -5720,7 +5721,7 @@ void MainWindow::loadPlugins()
         item->dockWidget->setAllowedAreas(Qt::AllDockWidgetAreas);
         item->dockWidget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
         item->dockWidget->setWidget(item->widget);
-        item->dockWidget->setObjectName(plugin->getName());
+        item->dockWidget->setObjectName(plugin->name());
 
         addDockWidget(Qt::LeftDockWidgetArea, item->dockWidget);
 
@@ -5774,19 +5775,19 @@ void MainWindow::updatePlugin(PluginItem *item)
 
     if ( item->getMode() == QDltPlugin::ModeEnable ) // this is just for user information: what is going on ...
     {
-        qDebug() << "Enable" << item->getPlugin()->getName() << "with" << conffilename << "configuration file";
+        qDebug() << "Enable" << item->getPlugin()->name() << "with" << conffilename << "configuration file";
     }
     else if ( item->getMode() == QDltPlugin::ModeShow )
     {
-        qDebug() << "Show" << item->getPlugin()->getName() << "with" << conffilename << "configuration file";
+        qDebug() << "Show" << item->getPlugin()->name() << "with" << conffilename << "configuration file";
     }
     else if ( item->getMode() == QDltPlugin::ModeDisable )
     {
-        qDebug() << "Disable" << item->getPlugin()->getName();
+        qDebug() << "Disable" << item->getPlugin()->name();
     }
     else
     {
-        qDebug() << "Unknown mode" << item->getMode() << "in" << item->getPlugin()->getName();
+        qDebug() << "Unknown mode" << item->getMode() << "in" << item->getPlugin()->name();
     }
 
     //We should not need error handling when disabling the plugins, so we only call loadConfig when enabling the plugin !
@@ -6736,7 +6737,7 @@ void MainWindow::dropEvent(QDropEvent *event)
                 QList<QDltPlugin*> list = pluginManager.getDecoderPlugins();
                 for(int num=0;num<list.size();num++)
                 {
-                    items << list[num]->getName();
+                    items << list[num]->name();
                 }
 
                 /* check if decoder plugin list is empty */

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -31,9 +31,7 @@
 #include <QCompleter>
 #include <QStringListModel>
 
-#include "qdlt.h"
 #include "tablemodel.h"
-#include "project.h"
 #include "settingsdialog.h"
 #include "searchdialog.h"
 #include "filterdialog.h"

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -26,6 +26,7 @@
 #include "project.h"
 #include "dltuiutils.h"
 #include "dlt_user.h"
+#include "qdltoptmanager.h"
 
 
 const char *loginfo[] = {"default","off","fatal","error","warn","info","debug","verbose","","","","","","","","",""};
@@ -577,7 +578,7 @@ void PluginItem::update()
     }
 
     //qDebug() << this->getName() << *modeString << this->getFilename();
-    setData(0,0,QString("%1").arg(plugin->getName()));
+    setData(0,0,QString("%1").arg(plugin->name()));
     //setData(1,0,QString("%1").arg(types.join("")));
     setData(1,0,QString("%1").arg(*modeString));
     //setData(3,0,QString("%1").arg(list.size()));
@@ -587,15 +588,15 @@ void PluginItem::update()
 }
 
 QString PluginItem::getName(){
-    return plugin->getName();
+    return plugin->name();
 }
 
 QString PluginItem::getPluginVersion(){
-    return plugin->getPluginVersion();
+    return plugin->pluginVersion();
 }
 
 QString PluginItem::getPluginInterfaceVersion(){
-    return plugin->getPluginInterfaceVersion();
+    return plugin->pluginInterfaceVersion();
 }
 
 QString PluginItem::getFilename(){

--- a/src/project.h
+++ b/src/project.h
@@ -20,8 +20,10 @@
 #ifndef PROJECT_H
 #define PROJECT_H
 
-#include "qdlt.h"
-
+#include "qdltipconnection.h"
+#include "qdltserialconnection.h"
+#include "qdltplugin.h"
+#include "qdltsettingsmanager.h"
 
 #include <QTreeWidget>
 #include <QDockWidget>

--- a/src/regex_search_replace.h
+++ b/src/regex_search_replace.h
@@ -1,9 +1,9 @@
 #ifndef REGEX_SEARCH_REPLACE_H
 #define REGEX_SEARCH_REPLACE_H
 
-#include "project.h"
 #include <regex>
 #include <stdlib.h>
+#include <QString>
 
 
 static void apply_regex_string(QString &data, const QString& regex_search, const QString& regex_replace)

--- a/src/searchdialog.cpp
+++ b/src/searchdialog.cpp
@@ -20,6 +20,7 @@
 #include "searchdialog.h"
 #include "ui_searchdialog.h"
 #include "mainwindow.h"
+#include "qdltoptmanager.h"
 
 #include <QMessageBox>
 #include <QProgressBar>

--- a/src/searchdialog.h
+++ b/src/searchdialog.h
@@ -21,7 +21,6 @@
 #define SEARCHDIALOG_H
 
 #include <QDialog>
-#include "qdlt.h"
 #include <QTableView>
 #include <QTreeWidget>
 #include <QCheckBox>

--- a/src/searchtablemodel.cpp
+++ b/src/searchtablemodel.cpp
@@ -22,6 +22,7 @@
 #include "dltuiutils.h"
 #include "dlt_protocol.h"
 #include "regex_search_replace.h"
+#include "qdltoptmanager.h"
 
 SearchTableModel::SearchTableModel(const QString &,QObject *parent) :
     QAbstractTableModel(parent)

--- a/src/searchtablemodel.h
+++ b/src/searchtablemodel.h
@@ -23,7 +23,7 @@
 #include <QAbstractTableModel>
 
 #include "project.h"
-#include "qdlt.h"
+#include "qdltpluginmanager.h"
 
 #define DLT_VIEWER_SEARCHCOLUMN_COUNT FieldNames::Arg0
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -30,6 +30,7 @@
 #include "ui_settingsdialog.h"
 #include "version.h"
 #include "dltuiutils.h"
+#include "qdltsettingsmanager.h"
 
 
 #if (WIN32)

--- a/src/settingsdialog.h
+++ b/src/settingsdialog.h
@@ -23,7 +23,8 @@
 #include <QDialog>
 #include <QMainWindow>
 #include <QColorDialog>
-#include "qdlt.h"
+
+#include "qdltfile.h"
 
 #define AUTOCONNECT_DEFAULT_TIME 1000 // in ms
 

--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -25,6 +25,7 @@
 #include "fieldnames.h"
 #include "dltuiutils.h"
 #include "dlt_protocol.h"
+#include "qdltoptmanager.h"
 #include "regex_search_replace.h"
 
 static long int lastrow = -1; // necessary because object tablemodel can not be changed, so no member variable can be used

--- a/src/tablemodel.h
+++ b/src/tablemodel.h
@@ -27,7 +27,7 @@
 #include <QStyledItemDelegate>
 
 #include "project.h"
-#include "qdlt.h"
+#include "qdltpluginmanager.h"
 
 #define DLT_VIEWER_LIST_BUFFER_SIZE 100024
 #define DLT_VIEWER_COLUMN_COUNT FieldNames::Arg0


### PR DESCRIPTION
* tested with Qt 5.15.2 and Qt 6.2.2
* tested on Windows (MSVC 2019) and Linux (gcc 11)

* QDltPlugin doesn't need forwarded classes anymore
* moved includes from qdlt.h into respective headers

* analysis with clang and clazy now possible