### PR TITLE
QT6: CMakeLists update

### DIFF
--- a/BuildDltParser.pro
+++ b/BuildDltParser.pro
@@ -4,3 +4,4 @@ CXXFLAGS +=-Wunused
 TEMPLATE = subdirs
 CONFIG   += ordered
 SUBDIRS  += parser
+CONFIG += c++11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # 01.Oct.2016, Jack Smith <jack.smith@elektrobit.com>, Original Author
 
 cmake_minimum_required (VERSION 3.15)
-
+# implicitly calls version checks
 include(scripts/windows/version.cmake)
 include(scripts/linux/version.cmake)
 
@@ -39,26 +39,20 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
-find_package(Qt5 "5" REQUIRED COMPONENTS Core Network Widgets SerialPort PrintSupport)
-
-if(Qt5Core_VERSION VERSION_LESS "5.5.1")
-    # Presumably Qt5Core implies all dependent libs too
-    message(FATAL_ERROR "QT minimum version required: 5.5.1")
-endif()
-
 set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTOUIC ON)
+set (CMAKE_AUTORCC ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-get_target_property(DLT_QT5_LIBRARY_PATH Qt5::Core LOCATION)
-get_filename_component(DLT_QT5_LIB_DIR ${DLT_QT5_LIBRARY_PATH} DIRECTORY)
+get_target_property(DLT_QT_LIBRARY_PATH ${QT_PREFIX}::Core LOCATION)
+get_filename_component(DLT_QT_LIB_DIR ${DLT_QT_LIBRARY_PATH} DIRECTORY)
 
 if(NOT WIN32)
     option(DLT_USE_QT_RPATH "Use RPATH for QT_LIBRARY_PATH to support non-standard QT install locations" ON)
     if (DLT_USE_QT_RPATH)
         # Add Qt to the RPATH, so that there is no need to set LD_LIBRARY_PATH at runtime if Qt is installed in a non-standard location
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${DLT_QT5_LIB_DIR}")
+        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${DLT_QT_LIB_DIR}")
     endif()
 endif()
 
@@ -70,6 +64,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 add_compile_definitions(QT5)
+set(QT5_QT6_COMPAT_VERSION "5.14")
+# add compiler definition to be used for >= Qt 5.14 code
+if(${QT_PREFIX}Core_VERSION VERSION_GREATER_EQUAL ${QT5_QT6_COMPAT_VERSION})
+    add_compile_definitions(QT5_QT6_COMPAT)
+endif()
 
 option(DLT_USE_STANDARD_INSTALLATION_LOCATION "Use standard GNU installation locations" OFF)
 if(NOT WIN32)
@@ -132,7 +131,7 @@ message(STATUS "\tCMAKE_INSTALL_PREFIX:         ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "\tCMAKE_BUILD_TYPE:             ${CMAKE_BUILD_TYPE}")
 message(STATUS "\tCMAKE_SYSTEM_PROCESSOR:       ${CMAKE_SYSTEM_PROCESSOR}")
 message(STATUS "\tCMAKE_SYSTEM_NAME:            ${CMAKE_SYSTEM_NAME}")
-message(STATUS "\tDLT_QT5_LIB_DIR:               ${DLT_QT5_LIB_DIR}\n")
+message(STATUS "\tDLT_QT_LIB_DIR:               ${DLT_QT_LIB_DIR}\n")
 
 # Must be last
 include(scripts/windows/package.cmake)

--- a/examples/dlt-speed-plugin/CMakeLists.txt
+++ b/examples/dlt-speed-plugin/CMakeLists.txt
@@ -47,14 +47,9 @@ ELSE (QWT_FOUND)
   ENDIF (QWT_FIND_REQUIRED)
 ENDIF (QWT_FOUND)  
 
-
-# cmake 2.8.12 doesn't have AUTOUIC ??
-QT5_WRAP_UI( UI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/form.ui )
-
 add_library(speedplugin MODULE speedplugin.cpp
-                               form.cpp
-                               ${UI_HEADERS})
+                               form.cpp)
 
 target_include_directories(speedplugin PUBLIC ${QWT_INCLUDE_DIR})
-target_link_libraries(speedplugin qdlt Qt5::Widgets ${QWT_LIBRARY})
+target_link_libraries(speedplugin qdlt ${QT_PREFIX}::Widgets ${QWT_LIBRARY})
 install(TARGETS speedplugin DESTINATION deploy/plugins)

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -18,11 +18,11 @@ add_executable(dlt-parser main.cpp
     mainwindow.ui
     qdltparser.cpp)
 
-target_link_libraries(dlt-parser Qt5::Widgets)
+target_link_libraries(dlt-parser ${QT_PREFIX}::Widgets -lstdc++)
 
 set_target_properties(dlt-parser PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-    INSTALL_RPATH "$ORIGIN/../lib;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT5_LIB_DIR}>")
+    INSTALL_RPATH "$ORIGIN/../lib;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT_LIB_DIR}>")
 
     if(CMAKE_COMPILER_IS_GNUCXX)
     # https://stackoverflow.com/questions/45329372/ubuntu-recognizes-executable-as-shared-library-and-wont-run-it-by-clicking

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -17,12 +17,12 @@ set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTOUIC ON)
 
 function(add_plugin NAME)
-    target_link_libraries(${NAME} qdlt Qt5::Widgets)
+    target_link_libraries(${NAME} qdlt ${QT_PREFIX}::Widgets)
 
     set_target_properties(${NAME} PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/plugins
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/plugins
-        INSTALL_RPATH "$ORIGIN/../../lib;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT5_LIB_DIR}>")
+        INSTALL_RPATH "$ORIGIN/../../lib;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT_LIB_DIR}>")
 
     install(TARGETS ${NAME}
         DESTINATION "${DLT_PLUGIN_INSTALLATION_PATH}"

--- a/plugin/dltdbusplugin/CMakeLists.txt
+++ b/plugin/dltdbusplugin/CMakeLists.txt
@@ -15,9 +15,8 @@
 
 add_library(dltdbusplugin MODULE dltdbusplugin.cpp
     form.cpp
-    dbus.cpp
-    ${UI_HEADERS})
+    dbus.cpp)
 
-target_link_libraries(dltdbusplugin qdlt Qt5::Widgets )
+target_link_libraries(dltdbusplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dltdbusplugin)

--- a/plugin/dltlogstorageplugin/CMakeLists.txt
+++ b/plugin/dltlogstorageplugin/CMakeLists.txt
@@ -15,9 +15,8 @@
 
 add_library(dltlogstorageplugin MODULE dltlogstorageconfigcreatorplugin.cpp
     logstorageconfigcreatorform.cpp
-    logstoragefilter.cpp
-    ${UI_HEADERS})
+    logstoragefilter.cpp)
 
-target_link_libraries(dltlogstorageplugin qdlt Qt5::Widgets )
+target_link_libraries(dltlogstorageplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dltlogstorageplugin)

--- a/plugin/dltsystemviewerplugin/CMakeLists.txt
+++ b/plugin/dltsystemviewerplugin/CMakeLists.txt
@@ -15,9 +15,8 @@
 
 add_library(dltsystemviewerplugin MODULE
     dltsystemviewerplugin.cpp
-    form.cpp
-    ${UI_HEADERS})
+    form.cpp)
 
-target_link_libraries(dltsystemviewerplugin qdlt Qt5::Widgets )
+target_link_libraries(dltsystemviewerplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dltsystemviewerplugin)

--- a/plugin/dlttestrobotplugin/CMakeLists.txt
+++ b/plugin/dlttestrobotplugin/CMakeLists.txt
@@ -15,8 +15,7 @@
 #
 
 add_library(dlttestrobotplugin MODULE dlttestrobotplugin.cpp
-   form.cpp
-   ${UI_HEADERS})
+   form.cpp)
 
-target_link_libraries(dlttestrobotplugin qdlt Qt5::Widgets )
+target_link_libraries(dlttestrobotplugin qdlt ${QT_PREFIX}::Widgets )
 add_plugin(dlttestrobotplugin)

--- a/plugin/dltviewerplugin/CMakeLists.txt
+++ b/plugin/dltviewerplugin/CMakeLists.txt
@@ -15,7 +15,8 @@
 
 add_library(dltviewerplugin MODULE
     dltviewerplugin.cpp
-    form.cpp
-)
+    form.cpp)
+
+target_link_libraries(dltviewerplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dltviewerplugin)

--- a/plugin/dummycommandplugin/CMakeLists.txt
+++ b/plugin/dummycommandplugin/CMakeLists.txt
@@ -16,9 +16,8 @@
 #
 
 add_library(dummycommandplugin MODULE
-    dummycommandplugin.cpp
-	${UI_HEADERS})
+    dummycommandplugin.cpp)
 
-target_link_libraries(dummycommandplugin qdlt Qt5::Widgets )
+target_link_libraries(dummycommandplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dummycommandplugin)

--- a/plugin/dummycontrolplugin/CMakeLists.txt
+++ b/plugin/dummycontrolplugin/CMakeLists.txt
@@ -15,9 +15,8 @@
 #
 
 add_library(dummycontrolplugin MODULE dummycontrolplugin.cpp
-   form.cpp
-   ${UI_HEADERS})
+   form.cpp)
 
-target_link_libraries(dummycontrolplugin qdlt Qt5::Widgets )
+target_link_libraries(dummycontrolplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dummycontrolplugin)

--- a/plugin/dummydecoderplugin/CMakeLists.txt
+++ b/plugin/dummydecoderplugin/CMakeLists.txt
@@ -14,9 +14,8 @@
 #
 
 add_library(dummydecoderplugin MODULE
-    dummydecoderplugin.cpp
-    ${UI_HEADERS})
+    dummydecoderplugin.cpp)
 
-target_link_libraries(dummydecoderplugin qdlt Qt5::Widgets )
+target_link_libraries(dummydecoderplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dummydecoderplugin)

--- a/plugin/dummyviewerplugin/CMakeLists.txt
+++ b/plugin/dummyviewerplugin/CMakeLists.txt
@@ -15,9 +15,8 @@
 
 add_library(dummyviewerplugin MODULE
     dummyviewerplugin.cpp
-    form.cpp
-    ${UI_HEADERS})
+    form.cpp)
 
-target_link_libraries(dummyviewerplugin qdlt Qt5::Widgets )
+target_link_libraries(dummyviewerplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(dummyviewerplugin)

--- a/plugin/filetransferplugin/CMakeLists.txt
+++ b/plugin/filetransferplugin/CMakeLists.txt
@@ -19,9 +19,8 @@ add_library(filetransferplugin MODULE
     file.cpp
     imagepreviewdialog.cpp
     textviewdialog.cpp
-    configuration.cpp
-    ${UI_HEADERS})
+    configuration.cpp)
 
-target_link_libraries(filetransferplugin qdlt Qt5::Widgets Qt5::PrintSupport )
+target_link_libraries(filetransferplugin qdlt ${QT_PREFIX}::Widgets ${QT_PREFIX}::PrintSupport )
 
 add_plugin(filetransferplugin)

--- a/plugin/nonverboseplugin/CMakeLists.txt
+++ b/plugin/nonverboseplugin/CMakeLists.txt
@@ -15,9 +15,8 @@
 #
 
 add_library(nonverboseplugin MODULE
-    nonverboseplugin.cpp
-    ${UI_HEADERS})
+    nonverboseplugin.cpp)
 
-target_link_libraries(nonverboseplugin qdlt Qt5::Widgets )
+target_link_libraries(nonverboseplugin qdlt ${QT_PREFIX}::Widgets )
 
 add_plugin(nonverboseplugin)

--- a/qdlt/CMakeLists.txt
+++ b/qdlt/CMakeLists.txt
@@ -53,10 +53,10 @@ target_include_directories(qdlt PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
 target_link_libraries(qdlt PUBLIC
-    Qt5::Core
-    Qt5::Network
-    Qt5::Widgets
-    Qt5::SerialPort)
+    ${QT_PREFIX}::Core
+    ${QT_PREFIX}::Network
+    ${QT_PREFIX}::Widgets
+    ${QT_PREFIX}::SerialPort)
 
 if(WIN32)
     target_link_libraries(qdlt PUBLIC ws2_32)
@@ -65,7 +65,7 @@ endif()
 set_target_properties(qdlt PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-    INSTALL_RPATH "$ORIGIN;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT5_LIB_DIR}>")
+    INSTALL_RPATH "$ORIGIN;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT_LIB_DIR}>")
 
 install(TARGETS qdlt
     LIBRARY DESTINATION "${DLT_LIBRARY_INSTALLATION_PATH}"

--- a/scripts/linux/version.cmake
+++ b/scripts/linux/version.cmake
@@ -13,10 +13,33 @@ if(NOT LINUX AND NOT APPLE)
     return()
 endif()
 
-find_package(Qt5 "5" REQUIRED COMPONENTS Core)
-set(DLT_QT5_VERSION ${Qt5Core_VERSION} CACHE STRING "DLT_QT5_VERSION")
-get_target_property(DLT_QT5_LIBRARY_PATH Qt5::Core LOCATION)
-get_filename_component(DLT_QT5_LIB_DIR ${DLT_QT5_LIBRARY_PATH} DIRECTORY)
+set(QT5_MIN_VERSION_REQ "5.5.1")
+set(QT6_MIN_VERSION_REQ "6.2.0")
+
+# try to find QT6
+find_package(Qt6 "6" COMPONENTS Core Network PrintSupport SerialPort Widgets)
+if(Qt6_FOUND)
+    set(QT_PREFIX Qt6)
+    message(STATUS "Found Qt6 version: ${Qt6Core_VERSION}")
+    if(${QT_PREFIX}Core_VERSION VERSION_LESS ${QT6_MIN_VERSION_REQ})
+        # Presumably Qt6Core implies all dependent libs too
+        message(FATAL_ERROR "Due to SerialPort QT6 minimum version required: ${QT6_MIN_VERSION_REQ}")
+    endif()
+else()
+    find_package(Qt5 "5" REQUIRED COMPONENTS Core Network PrintSupport SerialPort Widgets)
+    if(Qt5_FOUND)
+        set(QT_PREFIX Qt5)
+        message(STATUS "Found Qt5 version: ${Qt5Core_VERSION}")
+        if(${QT_PREFIX}Core_VERSION VERSION_LESS ${QT5_MIN_VERSION_REQ})
+            # Presumably Qt5Core implies all dependent libs too
+            message(FATAL_ERROR "QT5 minimum version required: ${QT5_MIN_VERSION_REQ}")
+        endif()
+    endif()
+endif()
+
+set(DLT_QT_VERSION "${${QT_PREFIX}Core_VERSION}" CACHE STRING "DLT_QT_VERSION")
+get_target_property(DLT_QT_LIBRARY_PATH ${QT_PREFIX}::Core LOCATION)
+get_filename_component(DLT_QT_LIB_DIR ${DLT_QT_LIBRARY_PATH} DIRECTORY)
 
 find_package(Git REQUIRED)
 execute_process(
@@ -48,4 +71,4 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-set(DLT_VERSION_SUFFIX "STABLE-qt${DLT_QT5_VERSION}-r${GIT_PATCH_VERSION}_${CMAKE_CXX_LIBRARY_ARCHITECTURE}_${CMAKE_CXX_COMPILER_VERSION}")
+set(DLT_VERSION_SUFFIX "STABLE-qt${DLT_QT_VERSION}-r${GIT_PATCH_VERSION}_${CMAKE_CXX_LIBRARY_ARCHITECTURE}_${CMAKE_CXX_COMPILER_VERSION}")

--- a/scripts/windows/version.cmake
+++ b/scripts/windows/version.cmake
@@ -5,10 +5,33 @@ message(STATUS "windows/version.cmake ${CMAKE_CURRENT_SOURCE_DIR}")
 
 project(GenerateVersion CXX)
 
-find_package(Qt5 "5" REQUIRED COMPONENTS Core)
-set(DLT_QT5_VERSION ${Qt5Core_VERSION} CACHE STRING "DLT_QT5_VERSION")
-get_target_property(DLT_QT5_LIBRARY_PATH Qt5::Core LOCATION)
-get_filename_component(DLT_QT5_LIB_DIR ${DLT_QT5_LIBRARY_PATH} DIRECTORY)
+set(QT5_MIN_VERSION_REQ "5.5.1")
+set(QT6_MIN_VERSION_REQ "6.2.0")
+
+# try to find QT6
+find_package(Qt6 "6" COMPONENTS Core Network PrintSupport SerialPort Widgets)
+if(Qt6_FOUND)
+    set(QT_PREFIX Qt6)
+    message(STATUS "Found Qt6 version: ${Qt6Core_VERSION}")
+    if(${QT_PREFIX}Core_VERSION VERSION_LESS ${QT6_MIN_VERSION_REQ})
+        # Presumably Qt6Core implies all dependent libs too
+        message(FATAL_ERROR "Due to SerialPort QT6 minimum version required: ${QT6_MIN_VERSION_REQ}")
+    endif()
+else()
+    find_package(Qt5 "5" REQUIRED COMPONENTS Core Network PrintSupport SerialPort Widgets)
+    if(Qt5_FOUND)
+        set(QT_PREFIX Qt5)
+        message(STATUS "Found Qt5 version: ${Qt5Core_VERSION}")
+        if(${QT_PREFIX}Core_VERSION VERSION_LESS ${QT5_MIN_VERSION_REQ})
+            # Presumably Qt5Core implies all dependent libs too
+            message(FATAL_ERROR "QT5 minimum version required: ${QT5_MIN_VERSION_REQ}")
+        endif()
+    endif()
+endif()
+
+set(DLT_QT_VERSION "${${QT_PREFIX}Core_VERSION}" CACHE STRING "DLT_QT_VERSION")
+get_target_property(DLT_QT_LIBRARY_PATH ${QT_PREFIX}::Core LOCATION)
+get_filename_component(DLT_QT_LIB_DIR ${DLT_QT_LIBRARY_PATH} DIRECTORY)
 
 find_package(Git REQUIRED)
 execute_process(
@@ -45,4 +68,4 @@ string(REPLACE "141" "msvc2017" VS_VERSION ${VS_VERSION})
 string(REPLACE "142" "msvc2019" VS_VERSION ${VS_VERSION})
 string(REPLACE "143" "msvc2022" VS_VERSION ${VS_VERSION})
 
-set(DLT_VERSION_SUFFIX "STABLE-qt${DLT_QT5_VERSION}-r${GIT_PATCH_VERSION}_${VS_VERSION}_${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}")
+set(DLT_VERSION_SUFFIX "STABLE-qt${DLT_QT_VERSION}-r${GIT_PATCH_VERSION}_${VS_VERSION}_${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,11 @@
 # List of changes:
 # 01.Oct.2016, Jack Smith <jack.smith@elektrobit.com>, Original Author
 
-QT5_ADD_RESOURCES(UI_RESOURCES_RCC resources/resource.qrc)
+if("${QT_PREFIX}" STREQUAL "Qt6")
+    QT6_ADD_RESOURCES(UI_RESOURCES_RCC resources/resource.qrc)
+else()
+    QT5_ADD_RESOURCES(UI_RESOURCES_RCC resources/resource.qrc)
+endif()
 
 add_executable(dlt-viewer
     main.cpp
@@ -50,10 +54,10 @@ add_executable(dlt-viewer
 
 target_link_libraries(dlt-viewer
     qdlt
-    Qt5::Core
-    Qt5::Network
-    Qt5::Widgets
-    Qt5::SerialPort)
+    ${QT_PREFIX}::Core
+    ${QT_PREFIX}::Network
+    ${QT_PREFIX}::Widgets
+    ${QT_PREFIX}::SerialPort)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     # https://stackoverflow.com/questions/45329372/ubuntu-recognizes-executable-as-shared-library-and-wont-run-it-by-clicking
@@ -63,7 +67,7 @@ endif()
 
 set_target_properties(dlt-viewer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-    INSTALL_RPATH "$ORIGIN/../lib;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT5_LIB_DIR}>")
+    INSTALL_RPATH "$ORIGIN/../lib;$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT_LIB_DIR}>")
 
 install(TARGETS dlt-viewer
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}"

--- a/src/cmake/Darwin.cmake
+++ b/src/cmake/Darwin.cmake
@@ -15,7 +15,7 @@ set_target_properties (dlt-viewer PROPERTIES
   OUTPUT_NAME "DLT Viewer")
 
 # get the path for the macdeployqt tool
-get_target_property(MOC_LOCATION Qt5::moc LOCATION)
+get_target_property(MOC_LOCATION ${QT_PREFIX}::moc LOCATION)
 get_filename_component(MAC_DEPLOY_TOOL ${MOC_LOCATION}/../macdeployqt ABSOLUTE)
 
 # convert the target into a self contained app bundle

--- a/src/cmake/Windows.cmake
+++ b/src/cmake/Windows.cmake
@@ -1,10 +1,10 @@
 set(QT_LIBS
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Network
-  Qt5::PrintSupport
-  Qt5::SerialPort
-  Qt5::Widgets)
+  ${QT_PREFIX}::Core
+  ${QT_PREFIX}::Gui
+  ${QT_PREFIX}::Network
+  ${QT_PREFIX}::PrintSupport
+  ${QT_PREFIX}::SerialPort
+  ${QT_PREFIX}::Widgets)
 
 foreach(QT_LIB IN ITEMS ${QT_LIBS})
   get_target_property(LIBRARY_PATH ${QT_LIB} LOCATION)
@@ -14,28 +14,32 @@ foreach(QT_LIB IN ITEMS ${QT_LIBS})
       COMPONENT qt_libraries)
 endforeach()
 
+if("${QT_PREFIX}" STREQUAL "Qt5")
 install(FILES
-    "${DLT_QT5_LIB_DIR}/../plugins/bearer/qgenericbearer.dll"
+    "${DLT_QT_LIB_DIR}/../plugins/bearer/qgenericbearer.dll"
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}/bearer"
     COMPONENT qt_libraries)
+endif()
 install(FILES
-    "${DLT_QT5_LIB_DIR}/../plugins/iconengines/qsvgicon.dll"
+    "${DLT_QT_LIB_DIR}/../plugins/iconengines/qsvgicon.dll"
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}/iconengines"
     COMPONENT qt_libraries)
 install(FILES
-    "${DLT_QT5_LIB_DIR}/../plugins/platforms/qwindows.dll"
+    "${DLT_QT_LIB_DIR}/../plugins/platforms/qwindows.dll"
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}/platforms"
     COMPONENT qt_libraries)
 install(FILES
-    "${DLT_QT5_LIB_DIR}/../plugins/imageformats/qico.dll"
+    "${DLT_QT_LIB_DIR}/../plugins/imageformats/qico.dll"
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}/imageformats"
     COMPONENT qt_libraries)
+if("${QT_PREFIX}" STREQUAL "Qt5")
 install(FILES
-    "${DLT_QT5_LIB_DIR}/../plugins/printsupport/windowsprintersupport.dll"
+    "${DLT_QT_LIB_DIR}/../plugins/printsupport/windowsprintersupport.dll"
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}/printsupport"
     COMPONENT qt_libraries)
+endif()
 install(FILES
-    "${DLT_QT5_LIB_DIR}/../plugins/styles/qwindowsvistastyle.dll"
+    "${DLT_QT_LIB_DIR}/../plugins/styles/qwindowsvistastyle.dll"
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}/styles"
     COMPONENT qt_libraries)
 


### PR DESCRIPTION
Depends on https://github.com/COVESA/dlt-viewer/pull/246
Depends on https://github.com/COVESA/dlt-viewer/pull/236

* tested with Qt 5.15.2 and Qt 6.2.2
* tested on Windows (MSVC 2019) and Linux (gcc 11)

* CMakeLists support Qt6 and Qt5
* Note Qt5 must be at least 5.14
* removed QT5_WRAP_UI call as CMake 3+ handles that
* removed QT5_ADD_RESOURCES call as CMake 3+ handles that

Signed-off-by: Stephan Voigt <stephan.voigt2121@gmx.de>