### PR TITLE
QT6: Added support for QT6

### DIFF
--- a/parser/qdltparser.cpp
+++ b/parser/qdltparser.cpp
@@ -472,9 +472,11 @@ QStringList QDltParser::parseMessageLine(QFile &file,QString &line,int &linecoun
 bool  QDltParser::parseMessageId(QString text)
 {
     QStringList list;
-
+#ifdef QT5_QT6_COMPAT
+    list = text.split(" ",Qt::SkipEmptyParts);
+#else
     list = text.split(" ",QString::SkipEmptyParts);
-
+#endif
     for (int i = 0; i < list.size(); ++i)
     {
         if((list[i] == QString("#define")) && (list.size() > (i+2)))

--- a/plugin/dltdbusplugin/dltdbusplugin.cpp
+++ b/plugin/dltdbusplugin/dltdbusplugin.cpp
@@ -650,7 +650,7 @@ bool DltDBusPlugin::decodeMsg(QDltMsg &msg, int triggeredByUser)
     argument.setEndianness(msg.getEndianness());
     argument.setOffsetPayload(0);
     QByteArray dataText;
-    dataText.append(text);
+    dataText.append(text.toUtf8());
     argument.setData(dataText);
     msg.addArgument(argument);
 

--- a/plugin/dltdbusplugin/dltdbusplugin.h
+++ b/plugin/dltdbusplugin/dltdbusplugin.h
@@ -66,7 +66,7 @@ inline bool operator==(const DltDbusMethodKey &e1, const DltDbusMethodKey &e2)
            && e1.getSerial() == e2.getSerial();
 }
 
-inline uint qHash(const DltDbusMethodKey &key)
+inline size_t qHash(const DltDbusMethodKey &key)
 {
     return qHash(key.getSender()) ^ key.getSerial();
 }

--- a/plugin/dltlogstorageplugin/logstorageconfigcreatorform.cpp
+++ b/plugin/dltlogstorageplugin/logstorageconfigcreatorform.cpp
@@ -23,6 +23,9 @@
 #include "logstorageconfigcreatorform.h"
 #include "ui_logstorageconfigcreatorform.h"
 
+#include <QRegularExpression>
+#include <QValidator>
+
 LogstorageConfigCreatorForm::LogstorageConfigCreatorForm(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::LogstorageConfigCreatorForm),
@@ -41,12 +44,19 @@ LogstorageConfigCreatorForm::LogstorageConfigCreatorForm(QWidget *parent) :
         ui->comboBox_level->addItem(item);
 
     // define some basic lineEdit validators
+#ifdef QT5_QT6_COMPAT
+    ui->lineEdit_apid->setValidator(new QRegularExpressionValidator( QRegularExpression("[a-zA-Z0-9_,]{0,20}$|[.]{1}[*]{1}"), 0));
+    ui->lineEdit_ctid->setValidator(new QRegularExpressionValidator( QRegularExpression("[a-zA-Z0-9_,]{0,20}$|[.]{1}[*]{1}"), 0));
+    ui->lineEdit_fname->setValidator(new QRegularExpressionValidator( QRegularExpression("[a-zA-Z0-9_-]\\S{0,20}$"), 0));
+    ui->lineEdit_fsize->setValidator( new QRegularExpressionValidator( QRegularExpression("[1-9]\\d{0,7}$"), 0));
+    ui->lineEdit_nofiles->setValidator( new QRegularExpressionValidator( QRegularExpression("[1-9]\\d{0,2}$"), 0));
+#else
     ui->lineEdit_apid->setValidator(new QRegExpValidator( QRegExp("[a-zA-Z0-9_,]{0,20}$|[.]{1}[*]{1}"), 0));
     ui->lineEdit_ctid->setValidator(new QRegExpValidator( QRegExp("[a-zA-Z0-9_,]{0,20}$|[.]{1}[*]{1}"), 0));
     ui->lineEdit_fname->setValidator(new QRegExpValidator( QRegExp("[a-zA-Z0-9_-]\\S{0,20}$"), 0));
     ui->lineEdit_fsize->setValidator( new QRegExpValidator( QRegExp("[1-9]\\d{0,7}$"), 0));
     ui->lineEdit_nofiles->setValidator( new QRegExpValidator( QRegExp("[1-9]\\d{0,2}$"), 0));
-
+#endif
     setFilterDefaults();
 
     // create list of filters

--- a/plugin/dlttestrobotplugin/dlttestrobotplugin.cpp
+++ b/plugin/dlttestrobotplugin/dlttestrobotplugin.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <QtGui>
+#include <QTextStream>
 
 #include "dlttestrobotplugin.h"
 
@@ -109,8 +110,11 @@ bool DltTestRobotPlugin::controlMsg(int , QDltMsg &)
 
 bool DltTestRobotPlugin::stateChanged(int index, QDltConnection::QDltConnectionState connectionState,QString hostname){
 
+#ifdef QT5_QT6_COMPAT
+    qDebug() << ecuList->at(index) << "ConnectionState:" << connectionState << "Hostname:" << hostname << Qt::endl;
+#else
     qDebug() << ecuList->at(index) << "ConnectionState:" << connectionState << "Hostname:" << hostname << endl;
-
+#endif
     return true;
 }
 

--- a/plugin/dummycontrolplugin/dummycontrolplugin.cpp
+++ b/plugin/dummycontrolplugin/dummycontrolplugin.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <QtGui>
+#include <QTextStream>
 
 #include "dummycontrolplugin.h"
 
@@ -108,8 +109,11 @@ void DummyControlPlugin::updateCounters(int ,int )
 
 bool DummyControlPlugin::stateChanged(int index, QDltConnection::QDltConnectionState connectionState,QString hostname){
 
+#ifdef QT5_QT6_COMPAT
+    qDebug() << ecuList->at(index) << "ConnectionState:" << connectionState << "Hostname:" << hostname << Qt::endl;
+#else
     qDebug() << ecuList->at(index) << "ConnectionState:" << connectionState << "Hostname:" << hostname << endl;
-
+#endif
     return true;
 }
 

--- a/plugin/filetransferplugin/file.cpp
+++ b/plugin/filetransferplugin/file.cpp
@@ -49,8 +49,8 @@ File::File(QDltFile *qfile,QTreeWidgetItem *parent):QTreeWidgetItem(parent)
     fileData = NULL;
 
     this->setText(COLUMN_STATUS, "Incomplete");
-    this->setTextColor(COLUMN_STATUS,Qt::white);
-    this->setBackgroundColor(COLUMN_STATUS,Qt::red);
+    this->setForeground(COLUMN_STATUS,Qt::white);
+    this->setBackground(COLUMN_STATUS,Qt::red);
     this->setText(COLUMN_RECPACKAGES, "0");
 }
 
@@ -132,8 +132,8 @@ void File::setBuffersize(QString b){
 
 void File::setComplete(){
     this->setText(COLUMN_STATUS, "Complete");
-    this->setBackgroundColor(COLUMN_STATUS,Qt::green);
-    this->setTextColor(COLUMN_STATUS,Qt::black);
+    this->setForeground(COLUMN_STATUS,Qt::black);
+    this->setBackground(COLUMN_STATUS,Qt::green);
 }
 
 void File::errorHappens(QString filename, QString errorCode1, QString errorCode2, QString time){
@@ -150,8 +150,8 @@ void File::errorHappens(QString filename, QString errorCode1, QString errorCode2
 
     this->setText(COLUMN_FILEDATE,time);
     this->setText(COLUMN_STATUS, "ERROR");
-    this->setTextColor(COLUMN_STATUS,Qt::white);
-    this->setBackgroundColor(COLUMN_STATUS,Qt::red);
+    this->setForeground(COLUMN_STATUS,Qt::white);
+    this->setBackground(COLUMN_STATUS,Qt::red);
 
 }
 

--- a/plugin/filetransferplugin/form.cpp
+++ b/plugin/filetransferplugin/form.cpp
@@ -176,7 +176,7 @@ void Form::on_saveButton_clicked()
 void Form::savetofile()
 {
     QString path = QFileDialog::getExistingDirectory(this, tr("Save file to directory"), QDir::currentPath(), QFileDialog::DontResolveSymlinks);
-    if(path != NULL)
+    if(path != nullptr)
     {
         QDir::setCurrent(path); // because we want to keep the last selected path to offer next time again
         QTreeWidgetItemIterator it(ui->treeWidget,QTreeWidgetItemIterator::NoChildren );
@@ -276,7 +276,7 @@ void Form::on_saveRightButtonClicked()
     QString FiletoSave;
     QString path = QFileDialog::getExistingDirectory(this, tr("Save file to directory"), QDir::currentPath(), QFileDialog::DontResolveSymlinks);
 
-    if(path != NULL)
+    if(path != nullptr)
     {
         QDir::setCurrent(path); // because we want to keep the last selected path to offer next time again
         QTreeWidgetItemIterator it(ui->treeWidget,QTreeWidgetItemIterator::NoChildren );

--- a/plugin/nonverboseplugin/nonverboseplugin.cpp
+++ b/plugin/nonverboseplugin/nonverboseplugin.cpp
@@ -575,7 +575,7 @@ bool NonverbosePlugin::decodeMsg(QDltMsg &msg, int triggeredByUser)
                 argument.setTypeInfo(QDltArgument::DltTypeInfoStrg);
                 argument.setEndianness(msg.getEndianness());
                 argument.setOffsetPayload(offset);
-                data.append(pdu->description);
+                data.append(pdu->description.toUtf8());
                 argument.setData(data);
             }
             else {

--- a/plugin/nonverboseplugin/nonverboseplugin.h
+++ b/plugin/nonverboseplugin/nonverboseplugin.h
@@ -43,7 +43,7 @@ public:
     }
 
     friend bool operator==(const DltFibexKey &e1, const DltFibexKey &e2);
-    friend uint qHash(const DltFibexKey &key);
+    friend size_t qHash(const DltFibexKey &key);
 
     QString id;
     QString appid;
@@ -56,7 +56,7 @@ inline bool operator==(const DltFibexKey &e1, const DltFibexKey &e2)
            && (e1.appid == e2.appid) && (e1.ctid == e2.ctid);
 }
 
-inline uint qHash(const DltFibexKey &key)
+inline size_t qHash(const DltFibexKey &key)
 {
     return qHash(key.id) ^ qHash(key.appid) ^ qHash(key.ctid);
 }

--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -168,7 +168,7 @@ void QDltOptManager::parse(QStringList *opt)
         {
             QString p1 = opt->value(i+1);
 
-            if(p1!=0 && (p1.endsWith(".dlp") || p1.endsWith(".DLP")))
+            if(p1!=nullptr && (p1.endsWith(".dlp") || p1.endsWith(".DLP")))
              {
                 projectFile = QString("%1").arg(opt->at(i+1));
                 QFile Fout(projectFile);
@@ -199,7 +199,7 @@ void QDltOptManager::parse(QStringList *opt)
 
             QString l1 = opt->value(i+1);
 
-            if(l1!=0 && (l1.endsWith(".dlt")||l1.endsWith(".DLT")))
+            if(l1!=nullptr && (l1.endsWith(".dlt")||l1.endsWith(".DLT")))
              {
                 logFile = QString("%1").arg(l1);
                 QFile Fout(logFile);
@@ -225,7 +225,7 @@ void QDltOptManager::parse(QStringList *opt)
          {
             QString f1 = opt->value(i+1);
 
-            if(f1!=0 && (f1.endsWith(".dlf")||f1.endsWith(".DLF")))
+            if(f1!=nullptr && (f1.endsWith(".dlf")||f1.endsWith(".DLF")))
              {
                 filterFile = QString("%1").arg(f1);
                 QFile Fout(filterFile);
@@ -257,13 +257,13 @@ void QDltOptManager::parse(QStringList *opt)
             QString c1 = opt->value(i+1);
             QString c2 = opt->value(i+2);
 
-            if(c1!=0 && (c1.endsWith(".dlt")||c1.endsWith(".DLT")) && c2!=0)
+            if(c1!=nullptr && (c1.endsWith(".dlt")||c1.endsWith(".DLT")) && c2!=nullptr)
              {
                 convertSourceFile = QString("%1").arg(c1);
                 convertDestFile = QString("%1").arg(c2);
                 // check here already if the selected file exists
 
-                if(QFileInfo(convertSourceFile).exists())
+                if(QFileInfo::exists(convertSourceFile))
                  {
                     qDebug() << "Converting " << convertSourceFile << "to" << convertDestFile;
                     convert = true;
@@ -303,7 +303,7 @@ void QDltOptManager::parse(QStringList *opt)
             QString c = opt->value(i+1);
             QStringList args = c.split("|");
             commandline_mode = true;
-            if(c != 0 && args.size() > 1)
+            if(c != nullptr && args.size() > 1)
              {
                 pluginName = args.at(0);
                 commandName = args.at(1);

--- a/src/dltexporter.cpp
+++ b/src/dltexporter.cpp
@@ -1,7 +1,9 @@
+#include <algorithm>
 #include <QProgressDialog>
 #include <QMessageBox>
 #include <QApplication>
 #include <QClipboard>
+#include <QDebug>
 
 #include "dltexporter.h"
 #include "fieldnames.h"
@@ -74,7 +76,7 @@ bool DltExporter::start()
     /* Sort the selection list and create Row list */
     if(exportSelection == DltExporter::SelectionSelected && selection != NULL)
     {
-        qSort(selection->begin(), selection->end());
+        std::sort(selection->begin(), selection->end());
         selectedRows.clear();
         for(int num=0;num<selection->count();num++)
         {

--- a/src/ecudialog.cpp
+++ b/src/ecudialog.cpp
@@ -20,6 +20,7 @@
 #include "ecudialog.h"
 #include "ui_ecudialog.h"
 
+#include <QRegularExpression>
 #include <QSerialPort>
 
 EcuDialog::EcuDialog(QWidget *parent) :
@@ -193,7 +194,7 @@ QString EcuDialog::EthInterface()
 
 QString EcuDialog::Serialport()
 {
-    QRegExp rx("^(com|COM)\\d\\d*$");    // matches from COM0 to COM99
+    QRegularExpression rx("^(com|COM)\\d\\d*$");    // matches from COM0 to COM99
     if(ui->comboBoxPortSerial->currentText().contains(rx))
     {
         QString str = "\\\\.\\";

--- a/src/filterdialog.cpp
+++ b/src/filterdialog.cpp
@@ -21,6 +21,8 @@
 #include "ui_filterdialog.h"
 #include <QMessageBox>
 #include <QCloseEvent>
+#include <QRegularExpression>
+
 #include "dltuiutils.h"
 
 FilterDialog::FilterDialog(QWidget *parent) :
@@ -286,7 +288,7 @@ void FilterDialog::setFilterColour(QColor color)
    QPalette palette = ui->labelSelectedColor->palette();
    palette.setColor(QPalette::Active,this->backgroundRole(),color);
    palette.setColor(QPalette::Inactive,this->backgroundRole(),QColor(255,255,255,255));
-   palette.setColor(QPalette::Foreground,DltUiUtils::optimalTextColor(color));
+   palette.setColor(QPalette::WindowText,DltUiUtils::optimalTextColor(color));
    ui->labelSelectedColor->setPalette(palette);
 
 }
@@ -497,7 +499,7 @@ void FilterDialog::validate()
         return;
     }
 
-    QRegExp rx;
+    QRegularExpression rx;
     rx.setPattern(getPayloadText());
     if(!rx.isValid()) {
         QMessageBox::warning(this, "Warning", error.arg("PAYLOAD").arg(rx.pattern()).arg(rx.errorString()));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -17,6 +17,7 @@
  * @licence end@
  */
 
+#include <algorithm>
 #include <iostream>
 #include <QMimeData>
 #include <QTreeView>
@@ -40,7 +41,7 @@
 #include <QSerialPortInfo>
 #include <QNetworkProxyFactory>
 #include <QNetworkInterface>
-#include <QtAlgorithms>
+#include <QTextStream>
 
 
 /**
@@ -6534,7 +6535,11 @@ void MainWindow::filterUpdate()
             if(false == filter->compileRegexps())
             {
                 // This is also validated in the UI part
+#ifdef QT5_QT6_COMPAT
+                qDebug() << "Error compiling a regexp" << Qt::endl << "in" << __FILE__ << __LINE__;
+#else
                 qDebug() << "Error compiling a regexp" << endl << "in" << __FILE__ << __LINE__;
+#endif
             }
         }
 
@@ -6934,7 +6939,7 @@ int MainWindow::nearest_line(int line)
             if(lastFound < 0)
             {
                 QVector<qint64> sortedIndices = filterIndices;
-                qSort(sortedIndices);
+                std::sort(sortedIndices.begin(), sortedIndices.end());
 
                 int lastIndex = sortedIndices[0];
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -313,7 +313,7 @@
     <enum>Qt::NoFocus</enum>
    </property>
    <property name="features">
-    <set>QDockWidget::AllDockWidgetFeatures</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
    </property>
    <property name="windowTitle">
     <string>Project</string>

--- a/src/pulsebutton.cpp
+++ b/src/pulsebutton.cpp
@@ -27,14 +27,19 @@ PulseButton::PulseButton(QWidget *parent) :
      * Shape to curve that gives pleasant pulsing behaviour.
      * Loop forever */
     animationTimeline.setFrameRange(0, 100);
+#ifdef QT5_QT6_COMPAT
+    QEasingCurve easing(QEasingCurve::SineCurve);
+    animationTimeline.setEasingCurve(easing);
+#else
     animationTimeline.setCurveShape(QTimeLine::SineCurve);
+#endif
     animationTimeline.setLoopCount(0);
 
     connect(&animationTimeline, SIGNAL(frameChanged(int)), this, SLOT(frameChanged(int)));
     connect(&animationTimeline, SIGNAL(stateChanged(QTimeLine::State)), this, SLOT(animationStateChanged(QTimeLine::State)));
 
     /* Store the original background color */
-    baseColor = this->palette().background().color();
+    baseColor = this->palette().window().color();
 
     /* Let QT draw background whenever needed */
     setAutoFillBackground(true);

--- a/src/searchdialog.cpp
+++ b/src/searchdialog.cpp
@@ -469,7 +469,7 @@ void SearchDialog::findMessages(long int searchLine, long int searchBorder, QReg
             text += msg.toStringHeader();
             if ( msgIdEnabled==true )
             {
-                text += " "+QString().sprintf(msgIdFormat.toLatin1(),msg.getMessageId());
+                text += " "+QString::asprintf(msgIdFormat.toUtf8(),msg.getMessageId());
             }
             tempPayLoad = msg.toStringPayload();
 

--- a/src/searchtablemodel.cpp
+++ b/src/searchtablemodel.cpp
@@ -172,7 +172,7 @@ QVariant SearchTableModel::data(const QModelIndex &index, int role) const
             }
             return visu_data;
         case FieldNames::MessageId:
-            return QString().sprintf(project->settings->msgIdFormat.toLatin1(),msg.getMessageId());
+            return QString::asprintf(project->settings->msgIdFormat.toUtf8(),msg.getMessageId());
         default:
             if (index.column()>=FieldNames::Arg0)
             {

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -660,11 +660,11 @@ void SettingsDialog::on_checkBoxPluginsAutoload_stateChanged(int activated)
 
 void SettingsDialog::on_pushButtonMarkerColor_clicked()
 {
-    QColor selectedcolor = QColorDialog::getColor( ui->labelSelectedMarkerColor->palette().background().color().name() );
+    QColor selectedcolor = QColorDialog::getColor( ui->labelSelectedMarkerColor->palette().window().color().name() );
     QPalette palette = ui->labelSelectedMarkerColor->palette();
     palette.setColor(QPalette::Active,this->backgroundRole(),selectedcolor);
     palette.setColor(QPalette::Inactive,this->backgroundRole(),QColor(255,255,255,255));
-    palette.setColor(QPalette::Foreground,DltUiUtils::optimalTextColor(selectedcolor));
+    palette.setColor(QPalette::WindowText,DltUiUtils::optimalTextColor(selectedcolor));
     ui->labelSelectedMarkerColor->setPalette(palette);
 
     if(selectedcolor.isValid())

--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -261,7 +261,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
 
              return visu_data;
          case FieldNames::MessageId:
-             return QString().sprintf(project->settings->msgIdFormat.toLatin1() ,msg.getMessageId());
+             return QString::asprintf(project->settings->msgIdFormat.toUtf8() ,msg.getMessageId());
          default:
              if (index.column()>=FieldNames::Arg0)
              {


### PR DESCRIPTION
Depends on https://github.com/COVESA/dlt-viewer/pull/245
Depends on https://github.com/COVESA/dlt-viewer/pull/236

* tested with Qt 5.15.2 and Qt 6.2.3
* tested on Windows (MSVC 2022) and Linux (gcc 11)

* replaced QRegExp with QRegularExpression
* replaced qSort with std::sort
* replaced QString!=0 with QString!=nullptr
* replaced QByteArray.append(QString) with QByteArray.append(QByteArray)
* replaced sprintf() with asprintf()
* replaced load() with loadRelaxed()
* replaced store() with storeRelaxed()
* added ifdefs for Qt < 5.14

Signed-off-by: Stephan Voigt <stephan.voigt2121@gmx.de>