### PR TITLE
fix: persist bool args with DLT_TYLE_8BIT

### DIFF
--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -330,7 +330,7 @@ bool QDltArgument::getArgument(QByteArray &payload, bool verboseMode) const
         default:
             return false;
         }
-        if((typeInfo == DltTypeInfoSInt) || (typeInfo == DltTypeInfoUInt) || (typeInfo == DltTypeInfoFloa)) {
+        if((typeInfo == DltTypeInfoSInt) || (typeInfo == DltTypeInfoUInt) || (typeInfo == DltTypeInfoFloa) || (typeInfo == DltTypeInfoBool)) {
             switch(data.size())
             {
             case 1:


### PR DESCRIPTION
The DLT_TYLE info was missing for bool types. Added the TYLE in similar
way as for Ints or Floats.

Issue: #242