### PR TITLE
Enable to set a custom execution sequence for DLT Plugins

### DIFF
--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -193,6 +193,21 @@ QDltPlugin* QDltPluginManager::findPlugin(QString &name)
     return plugin;
 }
 
+void QDltPluginManager::initPluginPriority(const QStringList& desiredPrio)
+{
+    QStringList finalPrio;
+
+    if(plugins.size() > 1) {
+        int prio = 0;
+        for (int i = 0; i < desiredPrio.count(); ++i) {
+            QString pluginName(desiredPrio[i]);
+            if (setPluginPriority(pluginName, prio)) {
+                ++prio;
+            }
+        }
+    }
+}
+
 bool QDltPluginManager::decreasePluginPriority(const QString &name)
 {
     bool result = false;
@@ -261,6 +276,22 @@ bool QDltPluginManager::setPluginPriority(const QString name, int prio)
     }
 
     return result;
+}
+
+QStringList QDltPluginManager::getPluginPriorities() const
+{
+    QStringList finalPrio;
+
+    if(plugins.size() > 0) {
+        pMutex_pluginList->lock();
+        for(int num=0; num < plugins.size(); num++)
+        {
+            finalPrio << plugins[num]->getName();
+        }
+        pMutex_pluginList->unlock();
+    }
+
+    return finalPrio;
 }
 
 QList<QDltPlugin*> QDltPluginManager::getDecoderPlugins()
@@ -353,3 +384,4 @@ bool QDltPluginManager::initConnections(QStringList list)
 
     return true;
 }
+

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -215,7 +215,7 @@ bool QDltPluginManager::decreasePluginPriority(const QString &name)
     if(plugins.size() > 1)
     {
         pMutex_pluginList->lock();
-        for(int num=0; num<plugins.size()-1; num++)
+        for(int num=0; num < plugins.size()-1; ++num)
         {
             if(plugins[num]->getName() == name)
             {
@@ -238,7 +238,7 @@ bool QDltPluginManager::raisePluginPriority(const QString &name)
     if(plugins.size() > 1)
     {
         pMutex_pluginList->lock();
-        for(int num=1; num<plugins.size(); num++)
+        for(int num=1; num < plugins.size(); ++num)
         {
             if( plugins[num]->getName() == name)
             {
@@ -254,17 +254,20 @@ bool QDltPluginManager::raisePluginPriority(const QString &name)
     return result;
 }
 
-bool QDltPluginManager::setPluginPriority(const QString name, int prio)
+bool QDltPluginManager::setPluginPriority(const QString name, unsigned int prio)
 {
     bool result = false;
 
-    if(prio < plugins.size())
-    {
+    //if prio is too large, put to the end of the list
+    if(prio >= plugins.size()) {
+        prio = plugins.size() - 1;
+    }
+
+    if(plugins.size() > 1) {
         pMutex_pluginList->lock();
-        for(int num=0;num<plugins.size();num++)
-        {
-            if(plugins[num]->getName()==name) {
-                if(prio != num) {
+        for (int num = 0; num < plugins.size(); ++num) {
+            if (plugins[num]->getName() == name) {
+                if (prio != num) {
                     qDebug() << "changing prio of" << name << "from" << num << "to" << prio;
                     plugins.move(num, prio);
                 }
@@ -284,7 +287,7 @@ QStringList QDltPluginManager::getPluginPriorities() const
 
     if(plugins.size() > 0) {
         pMutex_pluginList->lock();
-        for(int num=0; num < plugins.size(); num++)
+        for(int num=0; num < plugins.size(); ++num)
         {
             finalPrio << plugins[num]->getName();
         }

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -1,8 +1,12 @@
 #include "qdltplugin.h"
+#include "qdltpluginmanager.h"
+
 
 #include <QDir>
+#include <QDebug>
 #include <QCoreApplication>
 #include <QPluginLoader>
+#include <QMutex>
 //#include <QMessageBox>
 #include <QTextStream>
 #include <QString>
@@ -13,6 +17,12 @@
 
 QDltPluginManager::QDltPluginManager()
 {
+    pMutex_pluginList = new QMutex();
+}
+
+QDltPluginManager::~QDltPluginManager()
+{
+    delete pMutex_pluginList;
 }
 
 int QDltPluginManager::size() const
@@ -24,12 +34,17 @@ int QDltPluginManager::sizeEnabled() const
 {
     int count = 0;
 
+    pMutex_pluginList->lock();
+
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
         if(plugin->getMode()>=QDltPlugin::ModeEnable)
             count++;
     }
+
+    pMutex_pluginList->unlock();
+
     return count;
 }
 QStringList QDltPluginManager::loadPlugins(const QString &settingsPluginPath)
@@ -96,7 +111,9 @@ QStringList QDltPluginManager::loadPluginsPath(QDir &dir)
                     QDltPlugin* item = new QDltPlugin();
                     item->loadPlugin(plugin);
                     item->initMessageDecoder(this);
+                    pMutex_pluginList->lock();
                     plugins.append(item);
+                    pMutex_pluginList->unlock();
 
                     //project.plugin->addTopLevelItem(item);
 
@@ -134,43 +151,123 @@ QStringList QDltPluginManager::loadPluginsPath(QDir &dir)
 
 void QDltPluginManager::loadConfig(QString pluginName,QString filename)
 {
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
         if(plugin->getName()==pluginName)
             plugin->setFilename(filename);
     }
+    pMutex_pluginList->unlock();
 }
 
 
 void QDltPluginManager::decodeMsg(QDltMsg &msg, int triggeredByUser)
 {
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
 
         if(plugin->decodeMsg(msg,triggeredByUser))
             break;
-
     }
+    pMutex_pluginList->unlock();
 }
 
 QDltPlugin* QDltPluginManager::findPlugin(QString &name)
 {
+    QDltPlugin *plugin = nullptr;
+
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
-        QDltPlugin *plugin = plugins[num];
-
-        if(plugin->getName()==name)
-            return plugin;
+        if(plugins[num]->getName()==name)
+        {
+            plugin = plugins[num];
+            break;
+        }
     }
-    return 0;
+    pMutex_pluginList->unlock();
+
+    return plugin;
+}
+
+bool QDltPluginManager::decreasePluginPriority(const QString &name)
+{
+    bool result = false;
+
+    if(plugins.size() > 1)
+    {
+        pMutex_pluginList->lock();
+        for(int num=0; num<plugins.size()-1; num++)
+        {
+            if(plugins[num]->getName() == name)
+            {
+                qDebug() << "decrease prio of" << name << "from" << num << "to" << num+1;
+                plugins.move(num, num+1);
+                result = true;
+                break;
+            }
+        }
+        pMutex_pluginList->unlock();
+    }
+
+    return result;
+}
+
+bool QDltPluginManager::raisePluginPriority(const QString &name)
+{
+    bool result = false;
+
+    if(plugins.size() > 1)
+    {
+        pMutex_pluginList->lock();
+        for(int num=1; num<plugins.size(); num++)
+        {
+            if( plugins[num]->getName() == name)
+            {
+                qDebug() << "raise prio of" << name << "from" << num << "to" << num-1;
+                plugins.move(num, num-1);
+                result = true;
+                break;
+            }
+        }
+        pMutex_pluginList->unlock();
+    }
+
+    return result;
+}
+
+bool QDltPluginManager::setPluginPriority(const QString name, int prio)
+{
+    bool result = false;
+
+    if(prio < plugins.size())
+    {
+        pMutex_pluginList->lock();
+        for(int num=0;num<plugins.size();num++)
+        {
+            if(plugins[num]->getName()==name) {
+                if(prio != num) {
+                    qDebug() << "changing prio of" << name << "from" << num << "to" << prio;
+                    plugins.move(num, prio);
+                }
+                result = true;
+                break;
+            }
+        }
+        pMutex_pluginList->unlock();
+    }
+
+    return result;
 }
 
 QList<QDltPlugin*> QDltPluginManager::getDecoderPlugins()
 {
     QList<QDltPlugin*> list;
 
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
@@ -178,6 +275,8 @@ QList<QDltPlugin*> QDltPluginManager::getDecoderPlugins()
         if(plugin->isDecoder() && plugin->getMode()>=QDltPlugin::ModeEnable)
             list.append(plugin);
     }
+    pMutex_pluginList->unlock();
+
     return list;
 }
 
@@ -185,6 +284,7 @@ QList<QDltPlugin*> QDltPluginManager::getViewerPlugins()
 {
     QList<QDltPlugin*> list;
 
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
@@ -192,50 +292,64 @@ QList<QDltPlugin*> QDltPluginManager::getViewerPlugins()
         if(plugin->isViewer() && plugin->getMode()>=QDltPlugin::ModeEnable)
             list.append(plugin);
     }
+    pMutex_pluginList->unlock();
+
     return list;
 }
 
 bool QDltPluginManager::stateChanged(int index, QDltConnection::QDltConnectionState connectionState,QString hostname)
 {
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
         if(plugin->isControl() )
             plugin->stateChanged(index,connectionState,hostname);
     }
+    pMutex_pluginList->unlock();
+
     return true;
 }
 
 bool  QDltPluginManager::autoscrollStateChanged(bool enabled)
 {
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
         if(plugin->isControl() )
             plugin->autoscrollStateChanged(enabled);
     }
+    pMutex_pluginList->unlock();
+
     return true;
 }
 
 
 bool QDltPluginManager::initControl(QDltControl *control)
 {
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
         if(plugin->isControl() )
             plugin->initControl(control);
     }
+    pMutex_pluginList->unlock();
+
     return true;
 }
 
 bool QDltPluginManager::initConnections(QStringList list)
 {
+    pMutex_pluginList->lock();
     for(int num=0;num<plugins.size();num++)
     {
         QDltPlugin *plugin = plugins[num];
         if(plugin->isControl() )
             plugin->initConnections(list);
     }
+    pMutex_pluginList->unlock();
+
     return true;
 }

--- a/qdlt/qdltpluginmanager.h
+++ b/qdlt/qdltpluginmanager.h
@@ -83,9 +83,11 @@ public:
     bool initConnections(QStringList list);
 
     //control plugin execution order
+    void initPluginPriority(const QStringList &desiredPrio);
     bool decreasePluginPriority(const QString &name);
     bool raisePluginPriority(const QString &name);
     bool setPluginPriority(const QString name, int prio);
+    QStringList getPluginPriorities() const;
 
 private:
     mutable QMutex* pMutex_pluginList;

--- a/qdlt/qdltpluginmanager.h
+++ b/qdlt/qdltpluginmanager.h
@@ -13,6 +13,7 @@
 */
 
 class QDltPlugin;
+class QMutex;
 
 class QDLT_EXPORT QDltPluginManager : public QDltMessageDecoder
 {
@@ -20,6 +21,7 @@ public:
 
     //! Constructor
     QDltPluginManager();
+    ~QDltPluginManager();
 
     //! The number of plugins
     /*!
@@ -80,7 +82,13 @@ public:
     bool initControl(QDltControl *control);
     bool initConnections(QStringList list);
 
+    //control plugin execution order
+    bool decreasePluginPriority(const QString &name);
+    bool raisePluginPriority(const QString &name);
+    bool setPluginPriority(const QString name, int prio);
+
 private:
+    mutable QMutex* pMutex_pluginList;
 
     //! The list of pointers to all loaded plugins
     QList<QDltPlugin*> plugins;

--- a/qdlt/qdltpluginmanager.h
+++ b/qdlt/qdltpluginmanager.h
@@ -86,7 +86,7 @@ public:
     void initPluginPriority(const QStringList &desiredPrio);
     bool decreasePluginPriority(const QString &name);
     bool raisePluginPriority(const QString &name);
-    bool setPluginPriority(const QString name, int prio);
+    bool setPluginPriority(const QString name, unsigned int prio);
     QStringList getPluginPriorities() const;
 
 private:

--- a/qdlt/qdltsettingsmanager.cpp
+++ b/qdlt/qdltsettingsmanager.cpp
@@ -227,6 +227,10 @@ void QDltSettingsManager::writeSettings()
     settings->setValue("startup/versionMajor", PACKAGE_MAJOR_VERSION);
     settings->setValue("startup/versionMinor", PACKAGE_MINOR_VERSION);
     settings->setValue("startup/versionPatch", PACKAGE_PATCH_LEVEL);
+
+    for(int i = 0; i < pluginExecutionPrio.count(); ++i) {
+        settings->setValue(QStringLiteral("plugin/default_prio/%1").arg(i), pluginExecutionPrio[i]);
+    }
 }
 
 void QDltSettingsManager::readSettingsLocal(QXmlStreamReader &xml)
@@ -467,5 +471,14 @@ void QDltSettingsManager::readSettings()
     updateContextLoadingFile = settings->value("startup/updateContextLoadingFile",1).toInt();
     updateContextsUnregister = settings->value("startup/updateContextsUnregister",0).toInt();
     msgIdFormat = settings->value("startup/msgIdFormat","[%08u]").toString();
+
+    // Read the plugin execution priority of a maximum of 100 plugins
+    for(int i = 0; i < 100; ++i)
+    {
+        QString lastValue(settings->value(QStringLiteral("plugin/default_prio/%1").arg(i),"").toString());
+        if( !lastValue.isEmpty() ) {
+            pluginExecutionPrio << lastValue;
+        }
+    }
 }
 

--- a/qdlt/qdltsettingsmanager.h
+++ b/qdlt/qdltsettingsmanager.h
@@ -121,6 +121,8 @@ public:
     int automaticTimezoneFromDlt; // project and local setting
     qlonglong utcOffset; // project and local setting
     int dst; // project and local setting
+
+    QStringList pluginExecutionPrio; //local setting
 };
 
 #endif // QDLTSETTINGSMANAGER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7340,9 +7340,15 @@ void MainWindow::on_pushButtonMovePluginUp_clicked()
 {
     QList<QTreeWidgetItem *> list = project.plugin->selectedItems();
 
-    if(list.count() == 1)
-    {
-        qDebug() << "up clicked!";
+    for(auto it = list.cbegin(); it != list.cend(); it++) {
+        pluginManager.raisePluginPriority((*it)->text(0));
+
+        const int row = project.plugin->indexOfTopLevelItem((*it));
+        if (row > 0) {
+            project.plugin->takeTopLevelItem(row);
+            project.plugin->insertTopLevelItem(row - 1, (*it));
+            project.plugin->setCurrentItem((*it));
+        }
     }
 }
 
@@ -7350,9 +7356,15 @@ void MainWindow::on_pushButtonMovePluginDown_clicked()
 {
     QList<QTreeWidgetItem *> list = project.plugin->selectedItems();
 
-    if(list.count() == 1)
-    {
-        qDebug() << "down clicked!";
+    for(auto it = list.cbegin(); it != list.cend(); it++) {
+        pluginManager.decreasePluginPriority((*it)->text(0));
+
+        const int row = project.plugin->indexOfTopLevelItem((*it));
+        if (row < project.plugin->topLevelItemCount() - 1) {
+            project.plugin->takeTopLevelItem(row);
+            project.plugin->insertTopLevelItem(row + 1, (*it));
+            project.plugin->setCurrentItem((*it));
+        }
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -852,6 +852,7 @@ void MainWindow::deleteactualFile()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+    // Shall we save the updated plugin execution priorities??
 
     settingsDlg->writeSettings(this);
     if(true == isSearchOngoing)
@@ -5824,6 +5825,13 @@ void MainWindow::loadPlugins()
         for(iter = errList.constBegin(); iter != errList.constEnd(); ++iter)
             QMessageBox::warning(0, QString("DLT Viewer"), (*iter).toLocal8Bit().constData());
     }
+
+    // Initialize Plugin Prio
+    pluginManager.initPluginPriority(settings->pluginExecutionPrio);
+
+    // Update settings with current priorities (maybe some plugins are not available anymore)
+    settings->pluginExecutionPrio = pluginManager.getPluginPriorities();
+    qDebug() << settings->pluginExecutionPrio;
 
     /* update plugin widgets */
     QList<QDltPlugin*> plugins = pluginManager.getPlugins();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -274,6 +274,9 @@ void MainWindow::initState()
     project.ecu = ui->configWidget;
     project.filter = ui->filterWidget;
     project.plugin = ui->pluginWidget;
+
+    connect(ui->pluginWidget, SIGNAL(pluginOrderChanged(QString, int)), this, SLOT(on_pluginWidget_pluginPriorityChanged(QString, int)));
+
     //project.settings = settings;
     project.settings = QDltSettingsManager::getInstance();
 
@@ -5405,6 +5408,11 @@ void MainWindow::on_configWidget_itemSelectionChanged()
     ui->action_menuConfig_Expand_All_ECUs->setEnabled(ecuitem && !appitem );
     ui->action_menuConfig_Collapse_All_ECUs->setEnabled(ecuitem && !appitem );
 
+}
+
+void MainWindow::on_pluginWidget_pluginPriorityChanged(const QString name, int prio)
+{
+    pluginManager.setPluginPriority(name, prio);
 }
 
 void MainWindow::updateScrollButton()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5302,10 +5302,31 @@ void MainWindow::on_pluginWidget_itemSelectionChanged()
     QList<QTreeWidgetItem *> list = project.plugin->selectedItems();
 
     if((list.count() >= 1) ) {
+        const int first_selected_item_index = project.plugin->indexOfTopLevelItem((PluginItem*) list.at(0));
+        const int last_selected_item_index = project.plugin->indexOfTopLevelItem(list[list.count()-1]);
+
         ui->action_menuPlugin_Edit->setEnabled(true);
         ui->action_menuPlugin_Hide->setEnabled(true);
         ui->action_menuPlugin_Show->setEnabled(true);
         ui->action_menuPlugin_Disable->setEnabled(true);
+
+        if((last_selected_item_index > 0) && (project.plugin->topLevelItemCount() > 1)) {
+            ui->pushButtonMovePluginUp->setEnabled(true);
+        }
+        else {
+            ui->pushButtonMovePluginUp->setEnabled(false);
+        }
+
+        if((first_selected_item_index < (project.plugin->topLevelItemCount() - 1)) && (project.plugin->topLevelItemCount() > 1)) {
+            ui->pushButtonMovePluginDown->setEnabled(true);
+        }
+        else {
+            ui->pushButtonMovePluginDown->setEnabled(false);
+        }
+    }
+    else {
+        ui->pushButtonMovePluginUp->setEnabled(false);
+        ui->pushButtonMovePluginDown->setEnabled(false);
     }
 }
 void MainWindow::on_filterWidget_itemSelectionChanged()
@@ -7296,6 +7317,26 @@ void MainWindow::on_actionAutoScroll_triggered(bool checked)
 
     // inform plugins about changed autoscroll status
     pluginManager.autoscrollStateChanged(settings->autoScroll);
+}
+
+void MainWindow::on_pushButtonMovePluginUp_clicked()
+{
+    QList<QTreeWidgetItem *> list = project.plugin->selectedItems();
+
+    if(list.count() == 1)
+    {
+        qDebug() << "up clicked!";
+    }
+}
+
+void MainWindow::on_pushButtonMovePluginDown_clicked()
+{
+    QList<QTreeWidgetItem *> list = project.plugin->selectedItems();
+
+    if(list.count() == 1)
+    {
+        qDebug() << "down clicked!";
+    }
 }
 
 void MainWindow::on_actionConnectAll_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7349,14 +7349,9 @@ void MainWindow::on_pushButtonMovePluginUp_clicked()
     QList<QTreeWidgetItem *> list = project.plugin->selectedItems();
 
     for(auto it = list.cbegin(); it != list.cend(); it++) {
-        pluginManager.raisePluginPriority((*it)->text(0));
-
-        const int row = project.plugin->indexOfTopLevelItem((*it));
-        if (row > 0) {
-            project.plugin->takeTopLevelItem(row);
-            project.plugin->insertTopLevelItem(row - 1, (*it));
-            project.plugin->setCurrentItem((*it));
-        }
+        const int index = project.plugin->indexOfTopLevelItem((*it));
+        //PluginWidget emits a signal that will trigger the Plugin Manager
+        project.plugin->raisePluginPriority(index);
     }
 }
 
@@ -7365,14 +7360,9 @@ void MainWindow::on_pushButtonMovePluginDown_clicked()
     QList<QTreeWidgetItem *> list = project.plugin->selectedItems();
 
     for(auto it = list.cbegin(); it != list.cend(); it++) {
-        pluginManager.decreasePluginPriority((*it)->text(0));
-
-        const int row = project.plugin->indexOfTopLevelItem((*it));
-        if (row < project.plugin->topLevelItemCount() - 1) {
-            project.plugin->takeTopLevelItem(row);
-            project.plugin->insertTopLevelItem(row + 1, (*it));
-            project.plugin->setCurrentItem((*it));
-        }
+        const int index = project.plugin->indexOfTopLevelItem((*it));
+        //PluginWidget emits a signal that will trigger the Plugin Manager
+        project.plugin->decreasePluginPriority(index);
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3052,6 +3052,23 @@ void MainWindow::on_pluginWidget_customContextMenuRequested(QPoint pos)
             connect(action, SIGNAL(triggered()), this, SLOT(action_menuPlugin_Enable_triggered()));
             menu.addAction(action);
         }
+
+        menu.addSeparator();
+
+        if(project.plugin->indexOfTopLevelItem(item) > 0)
+        {
+            action = new QAction(tr("Move Up..."), this);
+            connect(action, SIGNAL(triggered()), this, SLOT(on_pushButtonMovePluginUp_clicked()));
+            menu.addAction(action);
+        }
+
+        if(project.plugin->indexOfTopLevelItem(item) < (project.plugin->topLevelItemCount() - 1))
+        {
+            action = new QAction(tr("Move Down..."), this);
+            connect(action, SIGNAL(triggered()), this, SLOT(on_pushButtonMovePluginDown_clicked()));
+            menu.addAction(action);
+        }
+
         /* show popup menu */
         menu.exec(globalPos);
     }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -430,6 +430,9 @@ private slots:
     void on_action_menuFile_Open_triggered();
     void on_actionExport_triggered();
 
+    void on_pushButtonMovePluginUp_clicked();
+    void on_pushButtonMovePluginDown_clicked();
+
 public slots:
 
     void onNewTriggered(QString fileName);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -417,6 +417,8 @@ private slots:
 
     void on_pluginWidget_itemExpanded(QTreeWidgetItem* item);
 
+    void on_pluginWidget_pluginPriorityChanged(const QString name, int prio);
+
 // File methods
 
 private slots:

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -420,7 +420,7 @@
         <enum>QTabWidget::Rounded</enum>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <property name="elideMode">
         <enum>Qt::ElideNone</enum>
@@ -610,6 +610,30 @@
          <property name="bottomMargin">
           <number>2</number>
          </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QPushButton" name="pushButtonMovePluginUp">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Up</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButtonMovePluginDown">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Down</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
          <item>
           <widget class="PluginTreeWidget" name="pluginWidget">
            <property name="contextMenuPolicy">

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -51,7 +51,7 @@ void PluginTreeWidget::raisePluginPriority(int index)
 
 void PluginTreeWidget::decreasePluginPriority(int index)
 {
-    if (index > 0) {
+    if (index >= 0) {
         QTreeWidgetItem *pItem = takeTopLevelItem(index);
         insertTopLevelItem(index + 1, pItem);
         setCurrentItem(pItem);

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -21,7 +21,7 @@ void PluginTreeWidget::sortAccordingPriority(const QStringList& prio_list)
     }
 }
 
-bool PluginTreeWidget::setPluginPriority(const QString& name, int prio)
+bool PluginTreeWidget::setPluginPriority(const QString& name, unsigned int prio)
 {
     for(int num = 0; num < topLevelItemCount(); num++) {
         PluginItem *pItem = (PluginItem*) topLevelItem(num);

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -11,10 +11,11 @@ PluginTreeWidget::PluginTreeWidget(QObject *parent) :
 
 void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 {
+    const QTreeWidgetItem* dragged_item = this->currentItem();
     const QTreeWidgetItem* target_item = this->itemAt(event->pos());
 
     // Ignore event if moving over a child item
-    if(target_item != nullptr && target_item->parent() != nullptr){
+    if(dragged_item == nullptr || dragged_item->parent() != nullptr || (target_item != nullptr && target_item->parent() != nullptr)){
         event->ignore();
     }
     else{
@@ -28,8 +29,10 @@ void PluginTreeWidget::dropEvent(QDropEvent *event)
     QTreeWidgetItem* dragged_item = this->currentItem();
     const QTreeWidgetItem* target_item = this->itemAt(event->pos());
 
+    // Avoid dropping children
     // Allow drop only over top level items (or at the end)
-    if(target_item == nullptr || target_item->parent() == nullptr){
+    if( dragged_item != nullptr && dragged_item->parent() == nullptr &&
+         (target_item == nullptr || target_item->parent() == nullptr)){
         QTreeWidget::dropEvent(event);
         this->setCurrentItem(dragged_item);
         int new_position = this->indexOfTopLevelItem(dragged_item);

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -6,28 +6,15 @@
 PluginTreeWidget::PluginTreeWidget(QObject *parent) :
     QTreeWidget(qobject_cast<QWidget *>(parent))
 {
-}
-
-void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
-{
-    event->accept();
+    setDragDropMode(QAbstractItemView::InternalMove);
 }
 
 void PluginTreeWidget::dropEvent(QDropEvent *event)
 {
-    QStringList types = event->mimeData()->formats();
-    for(int i=0;i < types.size(); i++)
-    {
-        /* QT advertises our filteritems with this MIME identifier.
-         * We use this to identify when a filter item was dropped,
-         * instead of some other random data. */
-        if(types[i] == "application/x-qabstractitemmodeldatalist")
-        {
-            QTreeWidget::dropEvent(event);
-            emit filterItemDropped();
-            event->accept();
-            break;
-         }
-    }
+    QTreeWidgetItem* item = this->currentItem();
+    QTreeWidget::dropEvent(event);
+    this->setCurrentItem(item);
+
+    emit pluginOrderChanged(item->text(0), this->indexOfTopLevelItem(item));
 }
 

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -9,12 +9,35 @@ PluginTreeWidget::PluginTreeWidget(QObject *parent) :
     setDragDropMode(QAbstractItemView::InternalMove);
 }
 
+void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
+{
+    const QTreeWidgetItem* target_item = this->itemAt(event->pos());
+
+    // Ignore event if moving over a child item
+    if(target_item != nullptr && target_item->parent() != nullptr){
+        event->ignore();
+    }
+    else{
+        QTreeWidget::dragMoveEvent(event);
+    }
+}
+
+
 void PluginTreeWidget::dropEvent(QDropEvent *event)
 {
-    QTreeWidgetItem* item = this->currentItem();
-    QTreeWidget::dropEvent(event);
-    this->setCurrentItem(item);
+    QTreeWidgetItem* dragged_item = this->currentItem();
+    const QTreeWidgetItem* target_item = this->itemAt(event->pos());
 
-    emit pluginOrderChanged(item->text(0), this->indexOfTopLevelItem(item));
+    // Allow drop only over top level items (or at the end)
+    if(target_item == nullptr || target_item->parent() == nullptr){
+        QTreeWidget::dropEvent(event);
+        this->setCurrentItem(dragged_item);
+        int new_position = this->indexOfTopLevelItem(dragged_item);
+
+        emit pluginOrderChanged(dragged_item->text(0), new_position);
+    }
+    else{
+        event->ignore();
+    }
 }
 

--- a/src/plugintreewidget.h
+++ b/src/plugintreewidget.h
@@ -9,6 +9,7 @@ class PluginTreeWidget : public QTreeWidget
 public:
     explicit PluginTreeWidget(QObject *parent = 0);
     void dropEvent(QDropEvent *event);
+    void dragMoveEvent(QDragMoveEvent *event);
 
 signals:
     void pluginOrderChanged(const QString& name, int);

--- a/src/plugintreewidget.h
+++ b/src/plugintreewidget.h
@@ -8,11 +8,10 @@ class PluginTreeWidget : public QTreeWidget
     Q_OBJECT
 public:
     explicit PluginTreeWidget(QObject *parent = 0);
-    void dragMoveEvent(QDragMoveEvent *event);
     void dropEvent(QDropEvent *event);
 
 signals:
-    void filterItemDropped();
+    void pluginOrderChanged(const QString& name, int);
 public slots:
 
 };

--- a/src/plugintreewidget.h
+++ b/src/plugintreewidget.h
@@ -21,7 +21,7 @@ signals:
 public slots:
 
 private:
-    bool setPluginPriority(const QString& name, int prio);
+    bool setPluginPriority(const QString& name, unsigned int prio);
 
 };
 

--- a/src/plugintreewidget.h
+++ b/src/plugintreewidget.h
@@ -8,12 +8,20 @@ class PluginTreeWidget : public QTreeWidget
     Q_OBJECT
 public:
     explicit PluginTreeWidget(QObject *parent = 0);
+
+    void sortAccordingPriority(const QStringList& prio_list);
+    void raisePluginPriority(int index);
+    void decreasePluginPriority(int index);
+
     void dropEvent(QDropEvent *event);
     void dragMoveEvent(QDragMoveEvent *event);
 
 signals:
     void pluginOrderChanged(const QString& name, int);
 public slots:
+
+private:
+    bool setPluginPriority(const QString& name, int prio);
 
 };
 

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -560,30 +560,25 @@ void PluginItem::update()
     if(plugin->isCommand())
         types << "Command";
 
-    QString *modeString;
+    QString modeString;
     switch(plugin->getMode()){
         case 0:
-            modeString = new QString("Disabled");
+            modeString = QString("Disabled");
             break;
         case 1:
-            modeString = new QString("Enabled&Not visible");
+            modeString = QString("Enabled&Not visible");
             break;
         case 2:
-            modeString = new QString("Enabled&Visible");
+            modeString = QString("Enabled&Visible");
             break;
         default:
-            modeString = new QString("");
+            modeString = QString("");
             break;
     }
 
-    //qDebug() << this->getName() << *modeString << this->getFilename();
-    setData(0,0,QString("%1").arg(plugin->getName()));
-    //setData(1,0,QString("%1").arg(types.join("")));
-    setData(1,0,QString("%1").arg(*modeString));
-    //setData(3,0,QString("%1").arg(list.size()));
-    setData(2,0,QString("%1").arg(this->getFilename()));
-
-    delete modeString;
+    setText(0, plugin->getName());
+    setText(1, modeString);
+    setText(2, this->getFilename());
 }
 
 QString PluginItem::getName(){

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -535,6 +535,8 @@ PluginItem::PluginItem(QTreeWidgetItem *parent, QDltPlugin *_plugin)
     type = 0;
 
     plugin = _plugin;
+
+    this->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
 }
 
 PluginItem::~PluginItem()

--- a/src/project.h
+++ b/src/project.h
@@ -227,9 +227,8 @@ private:
 //Forward declaration
 class MyPluginDockWidget;
 
-class PluginItem  : public QObject, public QTreeWidgetItem
+class PluginItem  : public QTreeWidgetItem
 {
-    Q_OBJECT
 public:
 
     PluginItem(QTreeWidgetItem *parent, QDltPlugin *_plugin);
@@ -264,9 +263,6 @@ public:
     QPluginLoader *loader;
 
 private:
-    QString name;
-    QString pluginVersion;
-    QString pluginInterfaceVersion;
     QString filename;
 
     int type;

--- a/src/project.h
+++ b/src/project.h
@@ -21,6 +21,7 @@
 #define PROJECT_H
 
 #include "qdlt.h"
+#include "plugintreewidget.h"
 
 
 #include <QTreeWidget>
@@ -267,6 +268,7 @@ private:
 
     int type;
     int mode;
+    int prio;
 
     QDltPlugin *plugin;
 
@@ -299,7 +301,7 @@ public:
 
     QTreeWidget *ecu;
     QTreeWidget *filter;
-    QTreeWidget *plugin;
+    PluginTreeWidget *plugin;
     //SettingsDialog *settings;
     QDltSettingsManager *settings;
 


### PR DESCRIPTION
Currently, the execution sequence of DLT Plugins depends on the discovery/loading order.

According to QDir documentation, all plugins in a certain plugin folder are discovered/loaded alphabetically, but DLTViewer supports more than one plugin folder.

Some Plugins might require some others to be executed before (e.g. in most/some cases it could make sense that Decoder plugins are executed before Viewer Plugins)

This pull request allows the user to set a custom execution sequence for the DLT Plugins and store it in the project file. The plugins can be reordered by:
* context menu
* drag and drop
* dedicated buttons

General/DLT Viewer plugin execution sequence can also be modified in the settings file. However, new execution sequence is not stored automatically when closing the application.