### PR TITLE
Fix: Release pipeline

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,3 +1,4 @@
+---
 name: Release
 
 on:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build project
         run: scripts/darwin/build.sh
       - name: Archive artifact
-        run: zip DLT-macOS.zip -r build/release
+        run: zip DLT-macOS.zip -r build/dist
       - name: Upload DLT artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -26,9 +26,9 @@ jobs:
       - name: install qt 5
         run: brew install qt@5
       - name: install build environment
-        run: scripts/linux/install.sh
+        run: scripts/darwin/install.sh
       - name: Build project
-        run: scripts/linux/build.sh
+        run: scripts/darwin/build.sh
       - name: Archive artifact
         run: zip DLT-macOS.zip -r build/release
       - name: Upload DLT artifact

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           name: DLT-Windows-sdk
       - run: |
-          assetsZip=$(find . -name 'DLT*.zip' | while read -r asset ; do echo "-a $asset" ; done)
+          assetsZip=$(find . -name 'DLT*.zip' | xargs -I asset echo "-a asset" | xargs)
           VERSION=$(echo $VERSION | cut -d'/' -f3)
           tag_name="${GITHUB_REF##*/}"
           hub release create ${assetsZip} -m "$tag_name" "$tag_name"


### PR DESCRIPTION
A few minor changes to the MacOS job, so it succeeds, and the artefacts can be uploaded.
It now works on my fork (when a tag is pushed): https://github.com/agravgaard/dlt-viewer/actions/runs/2956350864.

Putting the assets on one line may not be necessary; I can drop that commit if you prefer.