### PR TITLE
[ISSUE #292] Fix dead-lock in the dltpluginmanager

### DIFF
--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -17,7 +17,7 @@
 
 QDltPluginManager::QDltPluginManager()
 {
-    pMutex_pluginList = new QMutex();
+    pMutex_pluginList = new QMutex(QMutex::Recursive);
 }
 
 QDltPluginManager::~QDltPluginManager()


### PR DESCRIPTION
- Changed the 'pMutex_pluginList' to work in the recursive mode

Signed-off-by: Vladyslav Goncharuk <svlad1990@gmail.com>