### PR TITLE
Fix build fail on Darwin.

### DIFF
--- a/scripts/darwin/package.cmake
+++ b/scripts/darwin/package.cmake
@@ -5,7 +5,7 @@ endif()
 # See build.sh and src/cmake/Darwin.cmake
 set(CPACK_GENERATOR External)
 
-get_target_property(MOC_LOCATION Qt5::moc LOCATION)
+get_target_property(MOC_LOCATION ${QT_PREFIX}::moc LOCATION)
 get_filename_component(MACDEPLOYQT_EXECUTABLE ${MOC_LOCATION}/../macdeployqt ABSOLUTE)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/scripts/darwin/macdeployqt.cmake.in" "${CMAKE_BINARY_DIR}/macdeployqt.cmake" @ONLY)
 


### PR DESCRIPTION
Darwin script still references Qt5 rather than Qt6. Changed to Qt6:moc