### PR TITLE
No viable conversion from 'QDltDataView' to 'QByteArray'

### DIFF
--- a/qdlt/qdltconnection.cpp
+++ b/qdlt/qdltconnection.cpp
@@ -75,7 +75,8 @@ void QDltConnection::add(const QByteArray &bytes)
 {
     bytesReceived += bytes.size();
 
-    data = dataView + bytes;
+    QByteArray dataViewArray = dataView;
+    data = dataViewArray + bytes;
 
     dataView.align(data);
 }


### PR DESCRIPTION
This approach is working on macOS arm64 architecture.