### PR TITLE
Add more keyboard shortcuts

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -495,6 +495,12 @@ void MainWindow::initView()
     applyConfig->setShortcut(Qt::Key_C | Qt::SHIFT | Qt::CTRL);
     connect(applyConfig, SIGNAL(triggered()), this, SLOT(on_applyConfig_clicked()));
     addAction(applyConfig);
+
+    /* Add shortcut to add filter */
+    QAction *addFilter = new QAction(this);
+    addFilter->setShortcut(Qt::Key_A | Qt::SHIFT | Qt::CTRL);
+    connect(addFilter, SIGNAL(triggered()), this, SLOT(on_action_menuFilter_Add_triggered()));
+    addAction(addFilter);
 }
 
 void MainWindow::initSignalConnections()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -469,6 +469,11 @@ void MainWindow::initView()
     connect(settingsDlg, SIGNAL(FilterPathChanged()), this, SLOT(on_actionDefault_Filter_Reload_triggered()));
     connect(settingsDlg, SIGNAL(PluginsAutoloadChanged()), this, SLOT(triggerPluginsAutoload()));
 
+    QAction *focusSearchTextbox = new QAction(this);
+    focusSearchTextbox->setShortcut(Qt::Key_L | Qt::CTRL);
+    connect(focusSearchTextbox, SIGNAL(triggered()), searchTextbox, SLOT(setFocus()));
+    addAction(focusSearchTextbox);
+
     searchComboBox = new QComboBox();
     searchComboBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     searchComboBox->setLineEdit(searchTextbox);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -489,6 +489,12 @@ void MainWindow::initView()
 
     /* Update the scrollbutton status */
     updateScrollButton();
+
+    /* Add shortcut to apply config */
+    QAction *applyConfig = new QAction(this);
+    applyConfig->setShortcut(Qt::Key_C | Qt::SHIFT | Qt::CTRL);
+    connect(applyConfig, SIGNAL(triggered()), this, SLOT(on_applyConfig_clicked()));
+    addAction(applyConfig);
 }
 
 void MainWindow::initSignalConnections()


### PR DESCRIPTION
Allows for faster mouseless usage
* Ctrl-L to focus search window
* Ctrl-Shift-A to add open add filter dialog
* Ctrl-Shift-C to apply filters