### PR TITLE
Allow mixing project and dlt file arguments directly

### DIFF
--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -342,6 +342,19 @@ void QDltOptManager::parse(QStringList *opt)
             log = true;
             qDebug()<< "Loading logfile " << logFile;
         }
+        else if(opt->at(i).endsWith(".dlp") || opt->at(i).endsWith(".DLP"))
+        {
+            if (project == true)
+            {
+                qDebug() << "\nError: Can only load one project file\n";
+                printUsage();
+                exit(-1);
+            }
+
+            projectFile = QString("%1").arg(opt->at(i));
+            project = true;
+            qDebug()<< "Loading projectfile " << projectFile;
+        }
 
      } // end of for loop
     printVersion(opt->at(0));


### PR DESCRIPTION
Decide which one it is based on extension. Simplifies usage from command line when dlt and project files are grouped in directories.