### PR TITLE
Add tooltips to logs

### DIFF
--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -347,6 +347,11 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
         return FieldNames::getColumnAlignment((FieldNames::Fields)index.column(),project->settings);
     }
 
+    if ( role == Qt::ToolTipRole )
+    {
+        return msg.toStringPayload().simplified();
+    }
+
      return QVariant();
  }
 


### PR DESCRIPTION
When logs are really long it's not possible to see all the contents. The easiest solution is to add simple tooltip to every log.