### PR TITLE
Fix more compilation warnings

### DIFF
--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -497,8 +497,7 @@ QString QDltArgument::toString(bool binary) const
                 text += QString("%1").arg((double)(*(float*)(data.constData())));
             else
             {
-                unsigned int tmp;
-                tmp = DLT_SWAP_32((unsigned int)(*(unsigned int*)(data.constData())));
+                const auto tmp = DLT_SWAP_32((unsigned int)(*(unsigned int*)(data.constData())));
                 void *buf = (void *) &tmp;
                 text += QString("%1").arg((double)(*((float*)buf)));
             }
@@ -507,7 +506,7 @@ QString QDltArgument::toString(bool binary) const
             if(endianness == DltEndiannessLittleEndian)
                 text += QString("%1").arg((double)(*(double*)(data.constData())));
             else {
-                unsigned int tmp = DLT_SWAP_64((unsigned long long)(*(unsigned long long*)(data.constData())));
+                const auto tmp = DLT_SWAP_64((unsigned long long)(*(unsigned long long*)(data.constData())));
                 void *buf = (void *) &tmp;
                 text += QString("%1").arg((double)(*((double*)buf)));
             }
@@ -615,7 +614,7 @@ QVariant QDltArgument::getValue() const
             if(endianness == DltEndiannessLittleEndian)
                 return QVariant((double)(*(double*)(data.constData())));
             else {
-                unsigned int tmp = DLT_SWAP_64((unsigned long long)(*(unsigned long long*)(data.constData())));
+                const auto tmp = DLT_SWAP_64((unsigned long long)(*(unsigned long long*)(data.constData())));
                 void *buf = (void*) &tmp;
                 return QVariant((double)(*((double*)buf)));
             }

--- a/qdlt/qdltmsg.cpp
+++ b/qdlt/qdltmsg.cpp
@@ -153,7 +153,7 @@ QString QDltMsg::getGmTimeWithOffsetString(qlonglong offset, bool dst)
 
 quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
 {
-    int sizeStorageHeader = 0;
+    quint32 sizeStorageHeader = 0;
     QString storageHeaderEcuId;
 
     /* empty message */
@@ -171,7 +171,7 @@ quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
         if(storageHeaderVersion==1)
         {
             sizeStorageHeader = sizeof(DltStorageHeader);
-            if(size < (quint32)(sizeStorageHeader))
+            if(size < sizeStorageHeader)
             {
                 // length error
                 return 0;
@@ -179,7 +179,7 @@ quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
         }
         else if(storageHeaderVersion==2)
         {
-            if(size < (int)(14))
+            if(size < 14)
             {
                 // length error
                 return 0;
@@ -199,7 +199,7 @@ quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
     }
 
     /* get DLT protocol version */
-    if(size < (quint32)(sizeStorageHeader+4)) {
+    if(size < sizeStorageHeader+4) {
         return 0;
     }
     quint32 htyp2 = *((quint32*) (data + sizeStorageHeader));
@@ -211,7 +211,7 @@ quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
         const DltStandardHeader *standardheader = 0;
         unsigned int extra_size,headersize;
 
-        if(size < (int)(sizeStorageHeader+sizeof(DltStandardHeader))) {
+        if(size < (sizeStorageHeader+sizeof(DltStandardHeader))) {
             return 0;
         }
 
@@ -228,7 +228,7 @@ quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
         }
         else
         {
-            if(size < (quint32)(DLT_SWAP_16(standardheader->len) + sizeStorageHeader))
+            if(size < (sizeStorageHeader + DLT_SWAP_16(standardheader->len)))
             {
                 // whole message does not fit
                 return 0;
@@ -239,8 +239,8 @@ quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
     }
     else if(versionNumber==2)
     {
-        quint32 headerLength = 7;
-        if(size < (int)(sizeStorageHeader+headerLength))
+        constexpr quint32 headerLength = 7;
+        if(size < (sizeStorageHeader+headerLength))
         {
             // length error
             return 0;
@@ -283,9 +283,9 @@ quint32 QDltMsg::checkMsgSize(const char *data,quint32 size,bool supportDLTv2)
         messageCounter = *((quint8*) (data + 4 + sizeStorageHeader));
 
         /* get Message Length */
-        quint16 messageLength = messageLength = qFromBigEndian(*((quint16*) (data + 5 + sizeStorageHeader)));
+        quint16 messageLength = qFromBigEndian(*((quint16*) (data + 5 + sizeStorageHeader)));
 
-        if(size < (quint32)(messageLength+sizeStorageHeader))
+        if(size < (sizeStorageHeader + messageLength))
         {
             // whole message does not fit
             return 0;
@@ -618,7 +618,7 @@ bool QDltMsg::setMsg(const QByteArray& buf, bool withStorageHeader,bool supportD
         messageCounter = *((quint8*) (buf.constData() + 4 + sizeStorageHeader));
 
         /* get Message Length : always*/
-        quint16 messageLength = messageLength = qFromBigEndian(*((quint16*) (buf.constData() + 5 + sizeStorageHeader)));
+        quint16 messageLength = qFromBigEndian(*((quint16*) (buf.constData() + 5 + sizeStorageHeader)));
 
         /* get Message Info : conditional */
         quint8 messageInfo = 0;

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -255,16 +255,16 @@ bool QDltPluginManager::raisePluginPriority(const QString &name)
     return result;
 }
 
-bool QDltPluginManager::setPluginPriority(const QString name, unsigned int prio)
+bool QDltPluginManager::setPluginPriority(const QString& name, int prio)
 {
     bool result = false;
 
-    //if prio is too large, put to the end of the list
-    if(prio >= (unsigned int) (plugins.size())) {
-        prio = plugins.size() - 1;
-    }
-
     if(plugins.size() > 1) {
+        //if prio is too large, put to the end of the list
+        if(prio >= plugins.size()) {
+            prio = plugins.size() - 1;
+        }
+
         pMutex_pluginList->lock();
         for (int num = 0; num < plugins.size(); ++num) {
             if (plugins[num]->name() == name) {

--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -29,23 +29,6 @@ int QDltPluginManager::size() const
     return plugins.size();
 }
 
-int QDltPluginManager::sizeEnabled() const
-{
-    int count = 0;
-
-    pMutex_pluginList->lock();
-
-    for(int num=0;num<plugins.size();num++)
-    {
-        QDltPlugin *plugin = plugins[num];
-        if(plugin->getMode()>=QDltPlugin::ModeEnable)
-            count++;
-    }
-
-    pMutex_pluginList->unlock();
-
-    return count;
-}
 QStringList QDltPluginManager::loadPlugins(const QString &settingsPluginPath)
 {
     QDir pluginsDir1;

--- a/qdlt/qdltpluginmanager.h
+++ b/qdlt/qdltpluginmanager.h
@@ -86,7 +86,7 @@ public:
     void initPluginPriority(const QStringList &desiredPrio);
     bool decreasePluginPriority(const QString &name);
     bool raisePluginPriority(const QString &name);
-    bool setPluginPriority(const QString name, unsigned int prio);
+    bool setPluginPriority(const QString& name, int prio);
     QStringList getPluginPriorities() const;
 
 private:

--- a/qdlt/qdltpluginmanager.h
+++ b/qdlt/qdltpluginmanager.h
@@ -29,12 +29,6 @@ public:
     */
     int size() const;
 
-    //! The number of plugins that are enabled
-    /*!
-      \return the number of loaded plugins and enabled.
-    */
-    int sizeEnabled() const;
-
     //! Loads all plugins from three directories.current working sub directory /plugin
     /*!
       The three directories:

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -21,7 +21,7 @@ void PluginTreeWidget::sortAccordingPriority(const QStringList& prio_list)
     }
 }
 
-bool PluginTreeWidget::setPluginPriority(const QString& name, unsigned int prio)
+bool PluginTreeWidget::setPluginPriority(const QString& name, int prio)
 {
     for(int num = 0; num < topLevelItemCount(); num++) {
         PluginItem *pItem = (PluginItem*) topLevelItem(num);

--- a/src/plugintreewidget.h
+++ b/src/plugintreewidget.h
@@ -21,7 +21,7 @@ signals:
 public slots:
 
 private:
-    bool setPluginPriority(const QString& name, unsigned int prio);
+    bool setPluginPriority(const QString& name, int prio);
 
 };
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -166,7 +166,7 @@ void SettingsDialog::assertSettingsVersion()
         msg.append("Yes    - Reset settings to factory defaults.\n");
         msg.append("No     - Continue loading settings and risk crashing the application.\n");
         msg.append("Cancel - Exit the viewer now.\n");
-        QMessageBox dlg("Warning", msg, QMessageBox::Warning, QMessageBox::Yes, QMessageBox::No, QMessageBox::Cancel);
+        QMessageBox dlg(QMessageBox::Warning, "Warning", msg, QMessageBox::Yes|QMessageBox::No|QMessageBox::Cancel);
         int btn = dlg.exec();
         if(btn == QMessageBox::Yes)
         {
@@ -193,7 +193,7 @@ void SettingsDialog::resetSettings()
         fh.close();
         if(false == fh.remove())
         {
-            QMessageBox err("Error", "Could not remove the settings file", QMessageBox::Critical, QMessageBox::Ok, 0, 0);
+            QMessageBox err(QMessageBox::Critical, "Error", "Could not remove the settings file", QMessageBox::Ok);
             err.exec();
         }
         else

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -245,7 +245,7 @@ void SettingsDialog::writeDlg()
     ui->checkBoxAutoMarkMarker->setCheckState(settings->autoMarkMarker?Qt::Checked:Qt::Unchecked);
     ui->checkBoxLoggingOnlyMode->setCheckState(settings->loggingOnlyMode?Qt::Checked:Qt::Unchecked);
     ui->checkBoxLoggingOnlyFilteredMessages->setCheckState(settings->loggingOnlyFilteredMessages?Qt::Checked:Qt::Unchecked);
-    ui->groupBoxMaxFileSizeMB->setChecked(settings->splitlogfile?Qt::Checked:Qt::Unchecked);
+    ui->groupBoxMaxFileSizeMB->setChecked(settings->splitlogfile);
     ui->lineEditMaxFileSizeMB->setText(QString("%1").arg(settings->fmaxFileSizeMB));
     ui->checkBoxAppendDateTime->setCheckState(settings->appendDateTime?Qt::Checked:Qt::Unchecked);
 
@@ -369,7 +369,7 @@ void SettingsDialog::writeDlg()
     ui->checkBoxMode->setCheckState(settings->showMode?Qt::Checked:Qt::Unchecked);
     ui->checkBoxNoar->setCheckState(settings->showNoar?Qt::Checked:Qt::Unchecked);
     ui->checkBoxPayload->setCheckState(settings->showPayload?Qt::Checked:Qt::Unchecked);
-    ui->groupBoxMessageId->setChecked(settings->showMsgId?Qt::Checked:Qt::Unchecked);
+    ui->groupBoxMessageId->setChecked(settings->showMsgId);
     ui->spinBox_showArguments->setValue(settings->showArguments);
 
     /* other */


### PR DESCRIPTION
Mainly due to deprecated methods and integer comparison of different signedness.