### PR TITLE
Rename dlt_common.c into dlt_common.cpp.

### DIFF
--- a/qdlt/CMakeLists.txt
+++ b/qdlt/CMakeLists.txt
@@ -16,7 +16,7 @@
 #
 
 add_library(qdlt SHARED
-    dlt_common.c
+    dlt_common.cpp
     qdltipconnection.cpp
     qdlttcpconnection.cpp
     qdltudpconnection.cpp

--- a/qdlt/dlt_common.cpp
+++ b/qdlt/dlt_common.cpp
@@ -14,14 +14,14 @@
  *
  * \author Alexander Wenzel <alexander.aw.wenzel@bmw.de> 2011-2012
  * 
- * \file dlt_common.c
+ * \file dlt_common.cpp
  * For further information see http://www.covesa.global/.
  * @licence end@
  */
 
 /*******************************************************************************
 **                                                                            **
-**  SRC-MODULE: dlt_common.c                                                  **
+**  SRC-MODULE: dlt_common.cpp                                                **
 **                                                                            **
 **  TARGET    : linux                                                         **
 **                                                                            **

--- a/qdlt/qdlt.pro
+++ b/qdlt/qdlt.pro
@@ -41,7 +41,7 @@ UI_DIR      = build/ui
 INCLUDEPATH = . ../src
 
 SOURCES +=  \
-    dlt_common.c \
+    dlt_common.cpp \
     qdltipconnection.cpp \
     qdltmessagedecoder.cpp \
     qdlttcpconnection.cpp \


### PR DESCRIPTION
This makes sure c++ compiler is used and not plain c, failing with some error like

[ 10%] Building C object qdlt/CMakeFiles/qdlt.dir/dlt_common.c.o
cd /dlt-viewer/obj-x86_64-linux-gnu/qdlt && /usr/bin/cc -DBYTE_ORDER=LITTLE_ENDIAN -DPLUGIN_INSTALLATION_PATH=\"/usr/lib/x86_64-linux-gnu/dlt-viewer/plugins\" -DQT5 -DQT5_QT6_COMPAT -DQT_CORE_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_SERIALPORT_LIB -DQT_VIEWER -D_TTY_POSIX_ -Dqdlt_EXPORTS -I/dlt-viewer/obj-x86_64-linux-gnu/qdlt -I/dlt-viewer/qdlt -I/dlt-viewer/obj-x86_64-linux-gnu/qdlt/qdlt_autogen/include -I/dlt-viewer/qdlt/../src -isystem /usr/include/x86_64-linux-gnu/qt6/QtCore -isystem /usr/include/x86_64-linux-gnu/qt6 -isystem /usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -isystem /usr/include/x86_64-linux-gnu/qt6/QtNetwork -isystem /usr/include/x86_64-linux-gnu/qt6/QtSerialPort -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/dlt-viewer=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -std=gnu99 -fPIC   -Wall -Wextra -pedantic -Wno-variadic-macros -Wno-strict-aliasing -fPIC -MD -MT qdlt/CMakeFiles/qdlt.dir/dlt_common.c.o -MF CMakeFiles/qdlt.dir/dlt_common.c.o.d -o CMakeFiles/qdlt.dir/dlt_common.c.o -c /dlt-viewer/qdlt/dlt_common.c
In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/qglobal.h:37,
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/QtGlobal:1,
                 from /dlt-viewer/qdlt/export_rules.h:1,
                 from /dlt-viewer/qdlt/dlt_common.h:67,
                 from /dlt-viewer/qdlt/dlt_common.c:70:
/usr/include/x86_64-linux-gnu/qt6/QtCore/qtypes.h:163:15: error: expected declaration specifiers or '...' before 'sizeof'
  163 | static_assert(sizeof(ptrdiff_t) == sizeof(size_t), "Weird ptrdiff_t and size_t definitions");
      |               ^~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qtypes.h:163:52: error: expected declaration specifiers or '...' before string constant
  163 | static_assert(sizeof(ptrdiff_t) == sizeof(size_t), "Weird ptrdiff_t and size_t definitions");
      |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/dlt-viewer/qdlt/dlt_common.c: In function 'dlt_message_header_flags':
/dlt-viewer/qdlt/dlt_common.c:753:47: warning: taking address of packed member of 'struct <anonymous>' may result in an unaligned pointer value [-Waddress-of-packed-member]
  753 |         timeinfo = localtime ((const time_t*)(&(msg->storageheader->seconds)));