### PR TITLE
install qoffscreen plugin on windows

### DIFF
--- a/build_sdk_windows_qt5_MSVC.bat
+++ b/build_sdk_windows_qt5_MSVC.bat
@@ -163,6 +163,9 @@ if %ERRORLEVEL% NEQ 0 GOTO ERROR_HANDLER
 copy %QTDIR%\plugins\platforms\qwindows.dll %DLT_VIEWER_SDK_DIR%\platforms
 if %ERRORLEVEL% NEQ 0 GOTO ERROR_HANDLER
 
+copy %QTDIR%\plugins\platforms\qoffscreen.dll %DLT_VIEWER_SDK_DIR%\platforms
+if %ERRORLEVEL% NEQ 0 GOTO ERROR_HANDLER
+
 if "%QTNO%"=="5" (
 	copy %QTDIR%\plugins\styles\qwindowsvistastyle.dll %DLT_VIEWER_SDK_DIR%\styles
 	if %ERRORLEVEL% NEQ 0 GOTO ERROR_HANDLER

--- a/src/cmake/Windows.cmake
+++ b/src/cmake/Windows.cmake
@@ -26,6 +26,7 @@ install(FILES
     COMPONENT qt_libraries)
 install(FILES
     "${DLT_QT_LIB_DIR}/../plugins/platforms/qwindows.dll"
+    "${DLT_QT_LIB_DIR}/../plugins/platforms/qoffscreen.dll"
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}/platforms"
     COMPONENT qt_libraries)
 install(FILES


### PR DESCRIPTION
https://github.com/COVESA/dlt-viewer/issues/508

offscreen plugin is required since this change: https://github.com/COVESA/dlt-viewer/commit/990abade4cfc19d6c7500fb78673128b1377cc51

Probably using `windeployqt`-tool for packaging could have avoid this bug