### PR TITLE
Removed creating tar from build

### DIFF
--- a/scripts/darwin/build.sh
+++ b/scripts/darwin/build.sh
@@ -68,4 +68,4 @@ echo "FULL_VERSION=${FULL_VERSION}"
 
 mkdir -p dist
 cp ../scripts/darwin/install.md dist
-tar -czvf "dist/DLTViewer-${FULL_VERSION}.tgz" -C ${INSTALL_DIR} .
+# tar -czvf "dist/DLTViewer-${FULL_VERSION}.tgz" -C ${INSTALL_DIR} .


### PR DESCRIPTION
Reduce the size of macOS artifacts that are created during the build CI/CD pipeline.


Changes:
removed tar command from build as after notarization, binaries are tar'ed