### PR TITLE
Minor tablemodel cleanup

### DIFF
--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -28,29 +28,21 @@
 #include "qdltoptmanager.h"
 
 static long int lastrow = -1; // necessary because object tablemodel can not be changed, so no member variable can be used
-char buffer[DLT_VIEWER_LIST_BUFFER_SIZE];
 
-
-void getmessage( int indexrow, long int filterposindex, unsigned int* decodeflag, QDltMsg* msg, QDltMsg* lastmsg, QDltFile* qfile, bool* success )
+void getmessage(int indexrow, long int filterposindex, unsigned int* decodeflag, QDltMsg* msg, QDltMsg* lastmsg, QDltFile* qfile, bool* success )
 {
- if ( indexrow == lastrow)
- {
-  *msg = *lastmsg;
- }
- else
- {
-  *success = qfile->getMsg(filterposindex, *msg);
-  *lastmsg = *msg;
-  *decodeflag = 1;
- }
- if ( indexrow == 0)
- {
-  lastrow = 0;
- }
- else
- {
-  lastrow = indexrow;
- }
+    if (indexrow == lastrow)
+    {
+        *msg = *lastmsg;
+    }
+    else
+    {
+        *success = qfile->getMsg(filterposindex, *msg);
+        *lastmsg = *msg;
+        *decodeflag = 1;
+    }
+
+    lastrow = indexrow;
 }
 
 
@@ -67,10 +59,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
      lastrow = -1;
  }
 
- TableModel::~TableModel()
- {
-
- }
+TableModel::~TableModel() = default;
 
 
  int TableModel::columnCount(const QModelIndex & /*parent*/) const

--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -90,6 +90,21 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
 
      long int filterposindex = 0;
 
+     auto decodeMessageWithPlugin = [&] {
+         if (QDltSettingsManager::getInstance()->value("startup/pluginsEnabled", true).toBool())
+         {
+             if ( decodeflag == 1 )
+             {
+                 decodeflag = 0;
+                 pluginManager->decodeMsg(msg, !QDltOptManager::getInstance()->issilentMode());
+                 last_decoded_msg = msg;
+             }
+             else
+             {
+                 msg = last_decoded_msg;
+             }
+         }
+     };
 
      if (index.isValid() == false)
      {
@@ -129,20 +144,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
           }
          }
 
-         if((QDltSettingsManager::getInstance()->value("startup/pluginsEnabled", true).toBool()))
-         {
-             if ( decodeflag == 1 )
-              {
-               decodeflag = 0;
-               last_decoded_msg = msg;
-               pluginManager->decodeMsg(msg,!QDltOptManager::getInstance()->issilentMode());
-               last_decoded_msg = msg;
-              }
-              else
-              {
-                msg = last_decoded_msg;
-              }
-         }
+         decodeMessageWithPlugin();
 
          switch(index.column())
          {
@@ -278,20 +280,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
          getmessage( index.row(), filterposindex, &decodeflag, &msg, &lastmsg, qfile, &success); // version2
 
          /* decode message if not already decoded */
-         if((QDltSettingsManager::getInstance()->value("startup/pluginsEnabled", true).toBool()))
-         {
-             if ( decodeflag == 1 )
-              {
-               decodeflag = 0;
-               last_decoded_msg = msg;
-               pluginManager->decodeMsg(msg,!QDltOptManager::getInstance()->issilentMode());
-               last_decoded_msg = msg;
-              }
-              else
-              {
-                msg = last_decoded_msg;
-              }
-         }
+         decodeMessageWithPlugin();
 
          /* Calculate background color and find optimal forground color */
          return QVariant(QBrush(DltUiUtils::optimalTextColor(getMsgBackgroundColor(msg,index.row(),filterposindex))));
@@ -303,20 +292,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
          getmessage( index.row(), filterposindex, &decodeflag, &msg, &lastmsg, qfile, &success); // version2
 
          /* decode message if not already decoded */
-         if((QDltSettingsManager::getInstance()->value("startup/pluginsEnabled", true).toBool()))
-         {
-             if ( decodeflag == 1 )
-              {
-               decodeflag = 0;
-               last_decoded_msg = msg;
-               pluginManager->decodeMsg(msg,!QDltOptManager::getInstance()->issilentMode());
-               last_decoded_msg = msg;
-              }
-              else
-              {
-                msg = last_decoded_msg;
-              }
-         }
+         decodeMessageWithPlugin();
 
          /* Calculate background color */
          return QVariant(QBrush(getMsgBackgroundColor(msg,index.row(),filterposindex)));
@@ -340,20 +316,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
         {
             return QString("!!CORRUPTED MESSAGE!!");
         }
-        if((QDltSettingsManager::getInstance()->value("startup/pluginsEnabled", true).toBool()))
-        {
-            if ( decodeflag == 1 )
-            {
-                decodeflag = 0;
-                last_decoded_msg = msg;
-                pluginManager->decodeMsg(msg,!QDltOptManager::getInstance()->issilentMode());
-                last_decoded_msg = msg;
-            }
-            else
-            {
-                msg = last_decoded_msg;
-            }
-        }
+        decodeMessageWithPlugin();
 
         return toStringPayload(msg);
     }

--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -27,6 +27,9 @@
 #include "dlt_protocol.h"
 #include "qdltoptmanager.h"
 
+// this is done to have a basic caching mechanism in the table for the cases when the same dlt
+// message is accessed multiple times in the TableModel::data function several times in a row
+// TODO: replace with some kind of LRU cache to make it explicit
 static long int lastrow = -1; // necessary because object tablemodel can not be changed, so no member variable can be used
 
 void getMessage(int indexrow, QDltMsg* msg, QDltMsg* lastmsg, QDltFile* qfile, bool* success )
@@ -45,30 +48,27 @@ void getMessage(int indexrow, QDltMsg* msg, QDltMsg* lastmsg, QDltFile* qfile, b
     lastrow = indexrow;
 }
 
-
 TableModel::TableModel(const QString & /*data*/, QObject *parent)
-     : QAbstractTableModel(parent)
- {
-     qfile = NULL;
-     project = NULL;
-     pluginManager = NULL;
-     lastSearchIndex = -1;
-     emptyForceFlag = false;
-     loggingOnlyMode = false;
-     searchhit = -1;
-     lastrow = -1;
- }
+    : QAbstractTableModel(parent)
+{
+    qfile = NULL;
+    project = NULL;
+    pluginManager = NULL;
+    lastSearchIndex = -1;
+    emptyForceFlag = false;
+    loggingOnlyMode = false;
+    searchhit = -1;
+    lastrow = -1;
+}
 
 TableModel::~TableModel() = default;
 
+int TableModel::columnCount(const QModelIndex & /*parent*/) const
+{
+    return DLT_VIEWER_COLUMN_COUNT + project->settings->showArguments;
+}
 
- int TableModel::columnCount(const QModelIndex & /*parent*/) const
- {
-     return DLT_VIEWER_COLUMN_COUNT+project->settings->showArguments;
- }
-
-
- QVariant TableModel::data(const QModelIndex &index, int role) const
+QVariant TableModel::data(const QModelIndex &index, int role) const
  {
      static QDltMsg msg;
      static QDltMsg lastmsg;

--- a/src/tablemodel.h
+++ b/src/tablemodel.h
@@ -72,6 +72,8 @@ private:
     QColor manualMarkerColor;
     QList<unsigned long int> selectedMarkerRows;
     QColor getMsgBackgroundColor(QDltMsg &msg,int index,long int filterposindex) const;
+
+    QString toStringPayload(const QDltMsg&) const;
 };
 
 class HtmlDelegate : public QStyledItemDelegate


### PR DESCRIPTION
mainly code duplication removal. Much easier to review commit-by-commit. 

This activty revealed two directions for further improvements:
- explicit LRU caching in the model
- refactor searchtable model, which is basically a copy of this tablemodel