### PR TITLE
Add QDltOptmanager unit tests and minor cleanup

### DIFF
--- a/qdlt/qdltexporter.cpp
+++ b/qdlt/qdltexporter.cpp
@@ -99,12 +99,12 @@ bool QDltExporter::start()
     {
         if(!to->open(QIODevice::WriteOnly | QIODevice::Text))
         {
-            if ( true == QDltOptManager::getInstance()->issilentMode() )
-             {
-             qDebug() << QString("ERROR - cannot open the export file %1").arg(to->fileName());
-             }
-            else
-                ;//QMessageBox::critical(qobject_cast<QWidget *>(parent()), QString("DLT Viewer"),
+            if (QDltOptManager::getInstance()->issilentMode())
+            {
+                qDebug() << QString("ERROR - cannot open the export file %1").arg(to->fileName());
+            }
+            //else
+                //QMessageBox::critical(qobject_cast<QWidget *>(parent()), QString("DLT Viewer"),
                  //                 QString("Cannot open the export file %1").arg(to->fileName()));
             return false;
         }
@@ -113,12 +113,12 @@ bool QDltExporter::start()
     {
         if(!to->open(QIODevice::WriteOnly))
         {
-            if ( true == QDltOptManager::getInstance()->issilentMode() )
-             {
-             qDebug() << QString("ERROR - cannot open the export file %1").arg(to->fileName());
-             }
-            else
-                ;//QMessageBox::critical(qobject_cast<QWidget *>(parent()), QString("DLT Viewer"),
+            if (QDltOptManager::getInstance()->issilentMode() )
+            {
+                qDebug() << QString("ERROR - cannot open the export file %1").arg(to->fileName());
+            }
+            //else
+                //QMessageBox::critical(qobject_cast<QWidget *>(parent()), QString("DLT Viewer"),
                  //                 QString("Cannot open the export file %1").arg(to->fileName()));
             return false;
         }
@@ -130,12 +130,12 @@ bool QDltExporter::start()
         /* Write the first line of CSV file */
         if(!writeCSVHeader(to))
         {
-            if ( true == QDltOptManager::getInstance()->issilentMode() )
-             {
-             qDebug() << QString("ERROR - cannot open the export file %1").arg(to->fileName());
-             }
-            else
-                ;//QMessageBox::critical(qobject_cast<QWidget *>(parent()), QString("DLT Viewer"),
+            if(QDltOptManager::getInstance()->issilentMode())
+            {
+                qDebug() << QString("ERROR - cannot open the export file %1").arg(to->fileName());
+            }
+            //else
+                //QMessageBox::critical(qobject_cast<QWidget *>(parent()), QString("DLT Viewer"),
                  //                 QString("Cannot open the export file %1").arg(to->fileName()));
             return false;
         }

--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -81,32 +81,8 @@ void QDltOptManager::printVersion(QString appname)
 
 void QDltOptManager::printUsage()
 {
-#if (WIN32)
-    qDebug()<<"Usage: dlt-viewer.exe [OPTIONS] [logfile] [projectfile] [filterfile] [mf4file] [pcapfile]";
-#else
-    qDebug()<<"Usage: dlt-viewer [OPTIONS] [logfile] [projectfile] [filterfile] [mf4file] [pcapfile]";
-#endif
+    qDebug().noquote() << getHelpText();
 
-    qDebug()<<"\nOptions:";
-    qDebug()<<" [logfile]\tLoading one or more logfiles on startup (must end with .dlt)";
-    qDebug()<<" [projectfile]\tLoading project file on startup (must end with .dlp)";
-    qDebug()<<" [filterfile]\tLoading filterfile on startup (must end with .dlf)";
-    qDebug()<<" [pcapfile]\tImporting DLT/IPC from pcap file on startup (must end with .pcap)";
-    qDebug()<<" [mf4file]\tImporting DLT/IPC from mf4 file on startup (must end with .mf4)";
-    qDebug()<<" -h or --help\tPrint usage";
-    qDebug()<<" -c textfile\tConvert logfile file to textfile";
-    qDebug()<<" -u\tConversion will be done in UTF8 instead of ASCII";
-    qDebug()<<" -csv\tConversion will be done in CSV format";
-    qDebug()<<" -d\tConversion will NOT be done, save in dlt file format again instead";
-    qDebug()<<" -dd\tConversion will NOT be done, save as decoded messages in dlt format";
-    qDebug()<<" -b \"plugin|command|param1|..|param<n>\"\tExecute a plugin command with <n> parameters before loading log file.";
-    qDebug()<<" -e \"plugin|command|param1|..|param<n>\"\tExecute a plugin command with <n> parameters after loading log file.";
-    qDebug()<<" -s or --silent\tEnable silent mode without any GUI. Ideal for commandline usage.";
-    qDebug()<<" -stream\tTreat the input logfiles as DLT stream instead of DLT files.";
-    qDebug()<<" -t or --terminate\tTerminate DLT Viewer after command line execution.";
-    qDebug()<<" -v or --version\tOnly show version and buildtime information";
-    qDebug()<<" -w workingdirectory\tSet the working directory";
-    qDebug()<<" -delimiter <character>\tThe used delimiter for CSV export (Default: ,).";
     qDebug()<<"\nExamples:";
     qDebug()<<"  dlt-viewer.exe -t -c output.txt input.dlt";
     qDebug()<<"  dlt-viewer.exe -t -s -u -c output.txt input.dlt";
@@ -122,8 +98,6 @@ void QDltOptManager::printUsage()
 
 void QDltOptManager::parse(QStringList&& opt)
 {
-    QString str;
-
     qDebug() << "### Starting DLT Viewer";
 
     printVersion(opt.at(0));
@@ -152,7 +126,7 @@ void QDltOptManager::parse(QStringList&& opt)
     // 0==Binary 1==First Argument
     for (int i = 0; i < opt.size(); ++i)
      {
-        str = opt.at(i);
+        QString str = opt.at(i);
 
         if(str.compare("-h") == 0 || str.compare("--help") == 0)
           {
@@ -312,6 +286,38 @@ QString QDltOptManager::getCommandName(){return commandName;}
 QStringList QDltOptManager::getCommandParams(){return commandParams;}
 QString QDltOptManager::getWorkingDirectory() const { return workingDirectory; }
 char QDltOptManager::getDelimiter(){return delimiter;}
+
+QString QDltOptManager::getHelpText() const {
+    QStringList helpText;
+#if (WIN32)
+    helpText << "Usage: dlt-viewer.exe [OPTIONS] [logfile] [projectfile] [filterfile] [mf4file] [pcapfile]";
+#else
+    helpText << "Usage: dlt-viewer [OPTIONS] [logfile] [projectfile] [filterfile] [mf4file] [pcapfile]";
+#endif
+
+    helpText << "\nOptions:";
+    helpText << " [logfile]\tLoading one or more logfiles on startup (must end with .dlt)";
+    helpText << " [projectfile]\tLoading project file on startup (must end with .dlp)";
+    helpText << " [filterfile]\tLoading filterfile on startup (must end with .dlf)";
+    helpText << " [pcapfile]\tImporting DLT/IPC from pcap file on startup (must end with .pcap)";
+    helpText << " [mf4file]\tImporting DLT/IPC from mf4 file on startup (must end with .mf4)";
+    helpText << " -h or --help\tPrint usage";
+    helpText << " -c textfile\tConvert logfile file to textfile";
+    helpText << " -u\tConversion will be done in UTF8 instead of ASCII";
+    helpText << " -csv\tConversion will be done in CSV format";
+    helpText << " -d\tConversion will NOT be done, save in dlt file format again instead";
+    helpText << " -dd\tConversion will NOT be done, save as decoded messages in dlt format";
+    helpText << " -b \"plugin|command|param1|..|param<n>\"\tExecute a plugin command with <n> parameters before loading log file.";
+    helpText << " -e \"plugin|command|param1|..|param<n>\"\tExecute a plugin command with <n> parameters after loading log file.";
+    helpText << " -s or --silent\tEnable silent mode without any GUI. Ideal for commandline usage.";
+    helpText << " -stream\tTreat the input logfiles as DLT stream instead of DLT files.";
+    helpText << " -t or --terminate\tTerminate DLT Viewer after command line execution.";
+    helpText << " -v or --version\tOnly show version and buildtime information";
+    helpText << " -w workingdirectory\tSet the working directory";
+    helpText << " -delimiter <character>\tThe used delimiter for CSV export (Default: ,).";
+
+    return helpText.join('\n');
+}
 
 void QDltOptManager::reset() {
     project = false;

--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -143,7 +143,7 @@ void QDltOptManager::parse(QStringList&& opt)
          }
         else if(str.compare("-v") == 0 || str.compare("--version") == 0)
          {
-            printVersion(opt.at(0));
+            // version has already been printed above, just exit
             exit(0);
          }
          else if(str.compare("-t") == 0 || str.compare("--terminate") == 0)

--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -26,30 +26,11 @@
 #include <QDebug>
 #include <QFileInfo>
 
-// Global static pointer used to ensure a single instance of the class.
-QDltOptManager* QDltOptManager::instance;
-
-QDltOptManager::QDltOptManager()
-{
-    project = false;
-    silent_mode = false;
-    terminate=false;
-    convertionmode = e_ASCI;
-    commandline_mode = false;
-    delimiter=',';
-}
-
 QDltOptManager* QDltOptManager::getInstance()
 {
-    if (!instance)
-        instance = new QDltOptManager;
+    static QDltOptManager instance;
 
-    return instance;
-}
-
-QDltOptManager::QDltOptManager(QDltOptManager const&)
-{
-
+    return &instance;
 }
 
 const QStringList &QDltOptManager::getMf4Files() const

--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -120,42 +120,39 @@ void QDltOptManager::printUsage()
     qDebug()<<"  dlt-viewer.exe -t -c output.txt input1.mf4 input2.mf4";
 }
 
-void QDltOptManager::parse(QStringList *opt)
+void QDltOptManager::parse(QStringList&& opt)
 {
     QString str;
 
     qDebug() << "### Starting DLT Viewer";
 
-    printVersion(opt->at(0));
+    printVersion(opt.at(0));
 
     qDebug() << "### Parsing Options";
 
      /* the default parameter - exactly one parameter - should either be
       * a dlt or a dlp file, so this enables the "doubleclick" feature
       */
-     //str = opt->at(0); && ( str.compare("-h)") != 0 || str.compare("-v") !=0  )
-     if(opt->size()==2  )
-       {
-           if(opt->at(1).endsWith(".dlp") || opt->at(1).endsWith(".DLP"))
-           {
-               projectFile = QString("%1").arg(opt->at(1));
-               project = true;
-               qDebug()<< "Project filename:" << projectFile;
-               return;
-           }
-           if(opt->at(1).endsWith(".dlt") || opt->at(1).endsWith(".DLT"))
-           {
-               const QString logFile = QString("%1").arg(opt->at(1));
-               logFiles += logFile;
-               qDebug()<< "DLT filename:" << logFile;
-               return;
-           }
-       }
+     //str = opt.at(0); && ( str.compare("-h)") != 0 || str.compare("-v") !=0  )
+    if (opt.size() == 2) {
+        if (opt.at(1).endsWith(".dlp") || opt.at(1).endsWith(".DLP")) {
+            projectFile = QString("%1").arg(opt.at(1));
+            project = true;
+            qDebug() << "Project filename:" << projectFile;
+            return;
+        }
+        if (opt.at(1).endsWith(".dlt") || opt.at(1).endsWith(".DLT")) {
+            const QString logFile = QString("%1").arg(opt.at(1));
+            logFiles += logFile;
+            qDebug() << "DLT filename:" << logFile;
+            return;
+        }
+    }
 
     // 0==Binary 1==First Argument
-    for (int i = 0; i < opt->size(); ++i)
+    for (int i = 0; i < opt.size(); ++i)
      {
-        str = opt->at(i);
+        str = opt.at(i);
 
         if(str.compare("-h") == 0 || str.compare("--help") == 0)
           {
@@ -172,7 +169,7 @@ void QDltOptManager::parse(QStringList *opt)
          }
         else if(str.compare("-v") == 0 || str.compare("--version") == 0)
          {
-            printVersion(opt->at(0));
+            printVersion(opt.at(0));
             exit(0);
          }
          else if(str.compare("-t") == 0 || str.compare("--terminate") == 0)
@@ -182,7 +179,7 @@ void QDltOptManager::parse(QStringList *opt)
          }
         else if(str.compare("-c")==0)
          {
-            QString c1 = opt->value(i+1);
+            QString c1 = opt.value(i+1);
 
             convertDestFile = QString("%1").arg(c1);
             // check here already if the selected file exists
@@ -194,7 +191,7 @@ void QDltOptManager::parse(QStringList *opt)
          }
          else if(str.compare("-delimiter")==0)
          {
-             QString c1 = opt->value(i+1);
+             QString c1 = opt.value(i+1);
 
              delimiter = QString("%1").arg(c1).front().toLatin1();
 
@@ -224,30 +221,30 @@ void QDltOptManager::parse(QStringList *opt)
          }
         else if(str.compare("-e")==0)
          {
-            QString c = opt->value(i+1);
+            QString c = opt.value(i+1);
             postPluginCommands += c;
             commandline_mode = true;
             ++i;
          }
         else if(str.compare("-b")==0)
          {
-            QString c = opt->value(i+1);
+            QString c = opt.value(i+1);
             prePluginCommands += c;
             commandline_mode = true;
             ++i;
          }
         else if (str.compare("-w") == 0)
         {
-            workingDirectory = opt->value(i+1);
+            workingDirectory = opt.value(i+1);
             ++i;
         }
-        else if(opt->at(i).endsWith(".dlt") || opt->at(i).endsWith(".DLT"))
+        else if(opt.at(i).endsWith(".dlt") || opt.at(i).endsWith(".DLT"))
         {
-            const QString logFile = QString("%1").arg(opt->at(i));
+            const QString logFile = QString("%1").arg(opt.at(i));
             logFiles += logFile;
             qDebug()<< "DLT filename:" << logFile;
         }
-        else if(opt->at(i).endsWith(".dlp") || opt->at(i).endsWith(".DLP"))
+        else if(opt.at(i).endsWith(".dlp") || opt.at(i).endsWith(".DLP"))
         {
             if (project == true)
             {
@@ -256,24 +253,24 @@ void QDltOptManager::parse(QStringList *opt)
                 exit(-1);
             }
 
-            projectFile = QString("%1").arg(opt->at(i));
+            projectFile = QString("%1").arg(opt.at(i));
             project = true;
             qDebug()<< "Project filename:" << projectFile;
         }
-        else if(opt->at(i).endsWith(".dlf") || opt->at(i).endsWith(".DLF"))
+        else if(opt.at(i).endsWith(".dlf") || opt.at(i).endsWith(".DLF"))
         {
-            filterFiles += QString("%1").arg(opt->at(i));
-            qDebug()<< "Filter filename:" << QString("%1").arg(opt->at(i));
+            filterFiles += QString("%1").arg(opt.at(i));
+            qDebug()<< "Filter filename:" << QString("%1").arg(opt.at(i));
         }
-        else if(opt->at(i).endsWith(".pcap") || opt->at(i).endsWith(".PCAP"))
+        else if(opt.at(i).endsWith(".pcap") || opt.at(i).endsWith(".PCAP"))
         {
-            const QString pcapFile = QString("%1").arg(opt->at(i));
+            const QString pcapFile = QString("%1").arg(opt.at(i));
             pcapFiles += pcapFile;
             qDebug()<< "Pcap filename:" << pcapFile;
         }
-        else if(opt->at(i).endsWith(".mf4") || opt->at(i).endsWith(".MF4"))
+        else if(opt.at(i).endsWith(".mf4") || opt.at(i).endsWith(".MF4"))
         {
-            const QString mf4File = QString("%1").arg(opt->at(i));
+            const QString mf4File = QString("%1").arg(opt.at(i));
             mf4Files += mf4File;
             qDebug()<< "MF4 filename:" << mf4File;
         }
@@ -315,3 +312,25 @@ QString QDltOptManager::getCommandName(){return commandName;}
 QStringList QDltOptManager::getCommandParams(){return commandParams;}
 QString QDltOptManager::getWorkingDirectory() const { return workingDirectory; }
 char QDltOptManager::getDelimiter(){return delimiter;}
+
+void QDltOptManager::reset() {
+    project = false;
+    terminate = false;
+    silent_mode = false;
+    commandline_mode = false;
+    convertionmode = e_ASCI;
+    inputmode = e_inputmode::DLT;
+    projectFile.clear();
+    logFiles.clear();
+    filterFiles.clear();
+    convertDestFile.clear();
+    pluginName.clear();
+    commandName.clear();
+    commandParams.clear();
+    prePluginCommands.clear();
+    postPluginCommands.clear();
+    workingDirectory.clear();
+    delimiter = ',';
+    pcapFiles.clear();
+    mf4Files.clear();
+}

--- a/qdlt/qdltoptmanager.h
+++ b/qdlt/qdltoptmanager.h
@@ -77,15 +77,11 @@ public:
     void reset();
 
 private:
-    QDltOptManager();
-    QDltOptManager(QDltOptManager const&);
-    static QDltOptManager *instance;
-
-    bool project;
-    bool terminate;
-    bool silent_mode;
-    bool commandline_mode;
-    e_convertionmode convertionmode;
+    bool project{false};
+    bool terminate{false};
+    bool silent_mode{false};
+    bool commandline_mode{false};
+    e_convertionmode convertionmode{e_ASCI};
     e_inputmode inputmode{e_inputmode::DLT};
 
     QString projectFile;
@@ -102,7 +98,7 @@ private:
     QStringList postPluginCommands; // command after loading log file
 
     QString  workingDirectory;
-    char delimiter;
+    char delimiter{','};
 };
 
 #endif //QDLTOPTMANAGER_H

--- a/qdlt/qdltoptmanager.h
+++ b/qdlt/qdltoptmanager.h
@@ -46,7 +46,7 @@ public:
     static QDltOptManager* getInstance();
     void printUsage();
     void printVersion(QString appname);
-    void parse(QStringList *opt);
+    void parse(QStringList&& opt);
 
     bool isProjectFile();
     bool isTerminate();
@@ -70,6 +70,9 @@ public:
     const QStringList &getPcapFiles() const;
     const QStringList &getMf4Files() const;
     char getDelimiter();
+
+    // only testing relevant
+    void reset();
 
 private:
     QDltOptManager();

--- a/qdlt/qdltoptmanager.h
+++ b/qdlt/qdltoptmanager.h
@@ -71,6 +71,8 @@ public:
     const QStringList &getMf4Files() const;
     char getDelimiter();
 
+    QString getHelpText() const;
+
     // only testing relevant
     void reset();
 

--- a/qdlt/tests/CMakeLists.txt
+++ b/qdlt/tests/CMakeLists.txt
@@ -1,15 +1,31 @@
-add_executable(test_tools
+add_executable(test_dltmessagematcher
     test_dltmessagematcher.cpp
 )
 target_link_libraries(
-  test_tools
+  test_dltmessagematcher
   PRIVATE
     GTest::gtest_main
     qdlt
 )
 
 add_test(
-  NAME test_tools
-  COMMAND $<TARGET_FILE:test_tools>
+  NAME test_dltmessagematcher
+  COMMAND $<TARGET_FILE:test_dltmessagematcher>
 )
 
+
+add_executable(test_dltoptmanager
+    test_dltoptmanager.cpp
+)
+
+target_link_libraries(
+  test_dltoptmanager
+  PRIVATE
+    GTest::gtest_main
+    qdlt
+)
+
+add_test(
+  NAME test_dltoptmanager
+  COMMAND $<TARGET_FILE:test_dltoptmanager>
+)

--- a/qdlt/tests/test_dltoptmanager.cpp
+++ b/qdlt/tests/test_dltoptmanager.cpp
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <qdltoptmanager.h>
+
+#include <QCommandLineParser>
+
+
+QString logMessageSink;
+
+void messageHandler(QtMsgType type, const QMessageLogContext &,
+                    const QString &msg) {
+    if (type == QtDebugMsg) {
+        logMessageSink.append(msg);
+    }
+}
+
+class OptManagerTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        m_manager = QDltOptManager::getInstance();
+
+        qInstallMessageHandler(messageHandler);
+    }
+
+    void SetUp() override {
+        m_manager->reset();
+    }
+
+    void TearDown() override {
+        logMessageSink.clear();
+    }
+
+    static QDltOptManager* m_manager;
+};
+
+QDltOptManager* OptManagerTest::m_manager = nullptr;
+
+TEST_F(OptManagerTest, txtConversion) {
+    auto args = QStringList() << "executable" << "-t" << "-c" << "output.txt" << "input.dlt";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_EQ(m_manager->getConvertDestFile(), "output.txt");
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, txtConversionSilentUtf8Mode) {
+    auto args = QStringList() << "executable" << "-t" << "-s" << "-u" << "-c" << "output.txt" << "input.dlt";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_TRUE(m_manager->issilentMode());
+    EXPECT_EQ(m_manager->getConvertDestFile(), "output.txt");
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_EQ(m_manager->get_convertionmode(), e_UTF8);
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, txtConversionSilentAsciiMode) {
+    auto args = QStringList() << "executable" << "-t" << "-s" << "-d" << "-c" << "output.txt" << "input.dlt";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_TRUE(m_manager->issilentMode());
+    EXPECT_EQ(m_manager->getConvertDestFile(), "output.txt");
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_EQ(m_manager->get_convertionmode(), e_DLT);
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, csvConversionSilentMode) {
+    auto args = QStringList() << "executable" << "-t" << "-s" << "-csv" << "-c" << "output.csv" << "input.dlt";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_TRUE(m_manager->issilentMode());
+    EXPECT_EQ(m_manager->getConvertDestFile(), "output.csv");
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_EQ(m_manager->get_convertionmode(), e_CSV);
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, txtConversionSilentDdlMode) {
+    auto args = QStringList() << "executable" << "-t" << "-s" << "decoded.dlp" << "-dd" << "-c" << "output.dlt" << "input.dlt";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_TRUE(m_manager->issilentMode());
+    EXPECT_EQ(m_manager->getConvertDestFile(), "output.dlt");
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_EQ(m_manager->get_convertionmode(), e_DDLT);
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+    EXPECT_EQ(m_manager->getProjectFile(), "decoded.dlp");
+}
+
+TEST_F(OptManagerTest, pluginPostCommands) {
+    auto args = QStringList() << "executable"
+                              << "-p"
+                              << "export.dlp"
+                              << "-e"
+                              << "\"Filetransfer Plugin|export|ftransferdir\""
+                              << "input.dlt";
+    m_manager->parse(std::move(args));
+
+    EXPECT_EQ(m_manager->getProjectFile(), "export.dlp");
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_TRUE(m_manager->getPostPluginCommands().contains("\"Filetransfer Plugin|export|ftransferdir\""));
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, pluginPreCommands) {
+    auto args = QStringList() << "executable"
+                              << "-b"
+                              << "\"Filetransfer Plugin|export|ftransferdir\""
+                              << "input.dlt";
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_TRUE(m_manager->getPrePluginCommands().contains("\"Filetransfer Plugin|export|ftransferdir\""));
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, multipleLogFiles) {
+    auto args = QStringList() << "executable" << "input1.dlt" << "input2.dlt";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input1.dlt"));
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input2.dlt"));
+}
+
+TEST_F(OptManagerTest, pcapFile) {
+    auto args = QStringList() << "executable" << "-t" << "-c" << "output.txt" << "input.pcap";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_EQ(m_manager->getConvertDestFile(), "output.txt");
+    EXPECT_TRUE(m_manager->getPcapFiles().contains("input.pcap"));
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, mf4Files) {
+    auto args = QStringList() << "executable" << "-t" << "-c" << "output.txt" << "input1.mf4" << "input2.mf4";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_EQ(m_manager->getConvertDestFile(), "output.txt");
+    EXPECT_TRUE(m_manager->getMf4Files().contains("input1.mf4"));
+    EXPECT_TRUE(m_manager->getMf4Files().contains("input2.mf4"));
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+}
+
+TEST_F(OptManagerTest, filterFile) {
+    auto args = QStringList() << "executable"
+                              << "input.dlt"
+                              << "filter.dlf"
+                              << "-c"
+                              << "out.dlt"
+                              << "-d"
+                              << "-s"
+                              << "-t";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(m_manager->getLogFiles().contains("input.dlt"));
+    EXPECT_TRUE(m_manager->getFilterFiles().contains("filter.dlf"));
+    EXPECT_EQ(m_manager->getConvertDestFile(), "out.dlt");
+    EXPECT_TRUE(m_manager->isCommandlineMode());
+    EXPECT_TRUE(m_manager->isTerminate());
+    EXPECT_TRUE(m_manager->issilentMode());
+}
+
+TEST_F(OptManagerTest, version) {
+    // impossible to check just version because there is a call to exit(0) in the qdltoptmanager
+    // but any output will be enough to check the version call because it is always printed
+    auto args = QStringList() << "executable" << "some.dlt";
+
+    m_manager->parse(std::move(args));
+
+    EXPECT_TRUE(logMessageSink.contains("Executable Name:"));
+    EXPECT_TRUE(logMessageSink.contains("Build time:"));
+    EXPECT_TRUE(logMessageSink.contains("Version:"));
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,10 +45,7 @@ int main(int argc, char *argv[])
     }
 
     QApplication a(argc, argv);
-
-    QStringList arguments = a.arguments();
-    QDltOptManager *opt = QDltOptManager::getInstance();
-    opt->parse(&arguments);
+    QDltOptManager::getInstance()->parse(a.arguments());
 
     MainWindow w;
     w.show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -17,7 +17,6 @@
  * @licence end@
  */
 
-#include <iostream>
 #include <algorithm>
 #include <QMimeData>
 #include <QTreeView>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5721,39 +5721,10 @@ void MainWindow::on_action_menuHelp_Info_triggered()
 }
 
 
-void MainWindow::on_action_menuHelp_Command_Line_triggered()
-{
-    // Please copy changes to QDltOptManager::getInstance().cpp - printUsage()
-
-    QMessageBox::information(0, QString("DLT Viewer - Command line usage\t\t\t\t\t"), // tabs used to expand mesage box !
-                         #ifdef WIN32
-                             QString("Usage: dlt-viewer.exe [OPTIONS] [logfile] [projectfile] [filterfile] [mf4file] [pcapfile]\n\n")+
-                             QString("Options:\n")+
-                         #else
-                             QString("Usage: dlt-viewer [OPTIONS] [logfile] [projectfile] [filterfile] [mf4file] [pcapfile]\n\n")+
-                             QString("Options:\n")+
-                         #endif
-                             QString(" [logfile]\t\t\tLoading one or more logfiles on startup (must end with .dlt)\n")+
-                             QString(" [projectfile]\t\tLoading project file on startup (must end with .dlp)\n")+
-                             QString(" [filterfile]\t\tLoading filterfile on startup (must end with .dlf)\n")+
-                             QString(" [pcapfile]\tImporting DLT/IPC from pcap file on startup (must end with .pcap)\n")+
-                             QString(" [mf4file]\tImporting DLT/IPC from mf4 file on startup (must end with .mf4)\n")+
-                             QString(" -h\t\t\tPrint usage\n")+
-                             QString(" -s\t\t\tEnable silent mode without any GUI. Ideal for commandline usage.\n")+
-                             QString(" -stream\tTreat the input logfiles as DLT stream instead of DLT files.\n")+
-                             QString(" -v\t\t\tShow version and buildtime information\n")+
-                             QString(" -c <textfile>\tConvert logfile to ASCII textfile\n")+
-                             QString(" -u\t\t\tExport logfile to UTF8 instead\n")+
-                             QString(" -csv\t\t\tExport logfile to csv ( Excel ) instead\n")+
-                             QString(" -d\t\t\tExport logfile to DLT format\n")+
-                             QString(" -dd\t\t\tExport logfile to  decoded DLT format\n")+
-                             QString(" -b <pluginname>|command|param1|..|param<n>\n\t\t\tExecute a command plugin with <n> parameters before loading log file\n")+
-                             QString(" -e <pluginname>|command|param1|..|param<n>\n\t\t\tExecute a command plugin with <n> parameters after loading log file\n")+
-                             QString(" -t\t\t\tTerminate DLT Viewer after command line execution\n")+
-                             QString(" -v\t\t\tShow version and buildtime information\n")+
-                             QString(" -w workingdirectory\tSet the working directory\n")+
-                             QString(" -delimiter <character>\tThe used delimiter for CSV export (Default: ,)\n")
-                             );
+void MainWindow::on_action_menuHelp_Command_Line_triggered() {
+    QMessageBox::information(
+                0, "DLT Viewer - Command line usage\t\t\t\t\t", // tabs used to expand message box !
+                QDltOptManager::getInstance()->getHelpText());
 }
 
 void MainWindow::on_pluginWidget_itemSelectionChanged()


### PR DESCRIPTION
These PR contains part of changes from the reverted https://github.com/COVESA/dlt-viewer/pull/543. The changes for arg parsing arguments that [caused some issues](https://github.com/COVESA/dlt-viewer/pull/543#issuecomment-2404238471) are dropped until it is clear why they happen and how to fix them. 

The most important part of this PR is unit tests for QDltOptmanager, other changes are minor and should not affect the app functionality.