### PR TITLE
Fix wheel scrolling of the main tableview

### DIFF
--- a/src/dlttableview.cpp
+++ b/src/dlttableview.cpp
@@ -26,6 +26,8 @@ void DltTableView::wheelEvent(QWheelEvent *event)
         auto val = event->angleDelta().y();
         emit changeFontSize((0 < val) - (val < 0));
         event->accept();
+    } else {
+        QTableView::wheelEvent(event);
     }
 }
 


### PR DESCRIPTION
The introduction of the Ctrl+Wheel combination broke the normal mouse table view scrolling. This fixes the issue