### PR TITLE
Fix compilation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+set(CMAKE_C_STANDARD 11)
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -48,6 +48,8 @@
 #include <QTextStream>
 #include <QTemporaryFile>
 #include <QtEndian>
+#include <QDir>
+#include <QDirIterator>
 
 /**
  * From QDlt.

--- a/src/src.pro
+++ b/src/src.pro
@@ -6,7 +6,7 @@ QT_VER_MIN = $$member(QT_VERSION, 1)
 
 CONFIG += c++1z
 *-gcc* {
-    QMAKE_CFLAGS += -std=gnu99
+    QMAKE_CFLAGS += -std=c11
     QMAKE_CFLAGS += -Wall
     QMAKE_CFLAGS += -Wextra
     #QMAKE_CXXFLAGS += -pedantic


### PR DESCRIPTION
# Commit 1: Add missing includes

**Why:**
Without the missing includes, we had incomplete types.

**What:**
Added the necessary includes to resolve the incomplete types issue.

# Commit 2: Set C standard to c11

**Why:**
`dlt_common.c` includes `<QtGlobal>` which implicitly includes `<qtypes.h>`, which contains a `static_assert` that requires the C11 standard. This was causing issues with the GCC compiler, which does not support `static_assert` in earlier C standards.

**What:**
Explicitly set the C standard to C11 to ensure compatibility with the `static_assert` usage in the code.