### PR TITLE
No use of QtGlobal in c-code

### DIFF
--- a/plugin/dlttestrobotplugin/dlttestrobotplugin.cpp
+++ b/plugin/dlttestrobotplugin/dlttestrobotplugin.cpp
@@ -108,16 +108,7 @@ bool DltTestRobotPlugin::controlMsg(int , QDltMsg &)
     return false;
 }
 
-bool DltTestRobotPlugin::stateChanged(int index, QDltConnection::QDltConnectionState connectionState,QString hostname){
-    Q_UNUSED(index)
-    Q_UNUSED(connectionState)
-    Q_UNUSED(hostname)
-
-#if QT_5_SUPPORTED_VERSION
-    //qDebug() << ecuList->at(index) << "ConnectionState:" << connectionState << "Hostname:" << hostname << Qt::endl;
-#else
-    //qDebug() << ecuList->at(index) << "ConnectionState:" << connectionState << "Hostname:" << hostname << endl;
-#endif
+bool DltTestRobotPlugin::stateChanged(int, QDltConnection::QDltConnectionState, QString) {
     return true;
 }
 

--- a/qdlt/dlt_types.h
+++ b/qdlt/dlt_types.h
@@ -59,7 +59,7 @@
 typedef int pid_t;
 #endif
 
-#ifdef TARGET_OS_MAC
+#ifdef __APPLE__
 typedef unsigned long speed_t;
 #else
 typedef unsigned int speed_t;

--- a/qdlt/dlt_user.h
+++ b/qdlt/dlt_user.h
@@ -71,7 +71,6 @@
   \{
 */
 
-#include "dlt_types.h"
 #include "dlt_common.h"
 
 #ifdef __cplusplus

--- a/qdlt/export_rules.h
+++ b/qdlt/export_rules.h
@@ -1,24 +1,20 @@
-#include <QtGlobal>
-
 #ifndef EXPORT_RULES_H
 #define EXPORT_RULES_H
 
 #if defined(QDLT_LIBRARY)
 # define QDLT_EXPORT Q_DECL_EXPORT
-# ifdef Q_OS_WIN
+# if defined(_WIN32) || defined(_WIN64)
 #  define QDLT_C_EXPORT __declspec(dllexport)
 # else
 #  define QDLT_C_EXPORT __attribute__((visibility("default")))
 # endif
 #else
 # define QDLT_EXPORT Q_DECL_IMPORT
-# ifdef Q_OS_WIN
+# if defined(_WIN32) || defined(_WIN64)
 #  define QDLT_C_EXPORT __declspec(dllimport)
 # else
 #  define QDLT_C_EXPORT
 # endif
 #endif
-
-#define QT_5_SUPPORTED_VERSION (QT_VERSION_MAJOR == 5 && QT_VERSION_MINOR >= 14) || (QT_VERSION_MAJOR >= 6)
 
 #endif // EXPORT_RULES_H

--- a/qdlt/qdltsegmentedmsg.h
+++ b/qdlt/qdltsegmentedmsg.h
@@ -25,7 +25,6 @@
 #include "export_rules.h"
 
 #include <qdltmsg.h>
-#include <dlt_types.h>
 
 //! Combine segmented network messages
 /*!

--- a/src/dltmsgqueue.cpp
+++ b/src/dltmsgqueue.cpp
@@ -1,6 +1,8 @@
 #include "dltmsgqueue.h"
 #include <QThread>
 
+#define QT_5_SUPPORTED_VERSION (QT_VERSION_MAJOR == 5 && QT_VERSION_MINOR >= 14) || (QT_VERSION_MAJOR >= 6)
+
 DltMsgQueue::DltMsgQueue(int size)
     : bufferSize(size),
       buffer(new QPair<QSharedPointer<QDltMsg>, int> [size]),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7139,14 +7139,10 @@ void MainWindow::filterUpdate()
 
         if(filter->enableRegexp_Appid || filter->enableRegexp_Context || filter->enableRegexp_Header || filter->enableRegexp_Payload)
         {
-            if(false == filter->compileRegexps())
+            if(!filter->compileRegexps())
             {
                 // This is also validated in the UI part
-#if QT_5_SUPPORTED_VERSION
-                qDebug() << "Error compiling a regexp" << Qt::endl << "in" << __FILE__ << __LINE__;
-#else
-                qDebug() << "Error compiling a regexp" << endl << "in" << __FILE__ << __LINE__;
-#endif
+                qDebug() << "Error compiling a regexp\nin" << __FILE__ << __LINE__;
             }
         }
 
@@ -7154,8 +7150,6 @@ void MainWindow::filterUpdate()
     }
     qfile.updateSortedFilter();
 }
-
-
 
 void MainWindow::on_tableView_customContextMenuRequested(QPoint pos)
 {


### PR DESCRIPTION
This c++ header is no longer in pure C-headers. This PR supersedes  https://github.com/COVESA/dlt-viewer/pull/513