### PR TITLE
Do not block UI when building ECUs tree

### DIFF
--- a/qdlt/CMakeLists.txt
+++ b/qdlt/CMakeLists.txt
@@ -45,6 +45,8 @@ add_library(qdlt SHARED
     qdltlrucache.hpp
     export_c_rules.h
     export_rules.h
+    qdltctrlmsg.cpp
+    qdltctrlmsg.h
 )
 
 target_compile_definitions(qdlt PRIVATE

--- a/qdlt/qdlt.pro
+++ b/qdlt/qdlt.pro
@@ -68,6 +68,7 @@ SOURCES +=  \
     fieldnames.cpp \
     qdltimporter.cpp \
     dltmessagematcher.cpp \
+    qdltctrlmsg.cpp \
 
 HEADERS += qdlt.h \
     export_rules.h \
@@ -101,6 +102,7 @@ HEADERS += qdlt.h \
     fieldnames.h \
     qdltimporter.h \
     dltmessagematcher.h \
+    qdltctrlmsg.h \
 
 unix:VERSION            = 1.0.0
 

--- a/qdlt/qdltctrlmsg.cpp
+++ b/qdlt/qdltctrlmsg.cpp
@@ -1,0 +1,151 @@
+#include "qdltctrlmsg.h"
+
+#include "dlt_common.h"
+
+#include <stdexcept>
+#include <cstring>
+#include <array>
+
+#include <QByteArray>
+
+namespace qdlt::msg::payload {
+
+namespace {
+using IdType = std::array<char, DLT_ID_SIZE>;
+
+QString asQString(IdType&& id) {
+    QString str;
+    for (size_t i = 0; i < id.size() && id[i] != '\0'; i++) {
+        str.append(id[i]);
+    }
+    return str;
+}
+
+template <typename T>
+T dltPayloadRead(const char *&dataPtr, int32_t &length, bool isBigEndian)
+{
+    if (sizeof(T) > static_cast<uint32_t>(length)) {
+        throw std::runtime_error("Invalid data length");
+    }
+
+    T value{};
+    std::memcpy(&value, dataPtr, sizeof(T));
+    dataPtr += sizeof(T);
+    length -= sizeof(T);
+
+    if constexpr (sizeof(T) == sizeof(uint32_t)) {
+        value = DLT_ENDIAN_GET_32((isBigEndian ? DLT_HTYP_MSBF : 0), value);
+    }
+
+    if constexpr (sizeof(T) == sizeof(uint16_t)) {
+        value = DLT_ENDIAN_GET_16((isBigEndian ? DLT_HTYP_MSBF : 0), value);
+    }
+
+    return value;
+}
+
+IdType dltPayloadReadId(const char *&dataPtr, int32_t &length)
+{
+    if (DLT_ID_SIZE > length) {
+        throw std::runtime_error("Invalid ID length");
+    }
+    IdType id{};
+    std::copy(dataPtr, dataPtr + DLT_ID_SIZE, id.begin());
+    dataPtr += DLT_ID_SIZE;
+    length -= DLT_ID_SIZE;
+
+    return id;
+}
+
+std::string dltPayloadReadString(const char *&dataPtr, int32_t &length, bool isBigEndian)
+{
+    uint16_t strLength = dltPayloadRead<uint16_t>(dataPtr, length, isBigEndian);
+    if (strLength > length) {
+        throw std::runtime_error("Invalid string length");
+    }
+    std::string str;
+    str.assign(dataPtr, strLength);
+    dataPtr += strLength;
+    length -= strLength;
+
+    return str;
+}
+}
+
+Type parse(const QByteArray& data, bool isBigEndian)
+{
+    int32_t length = data.length();
+    const char *dataPtr = data.data();
+
+    auto service_id = dltPayloadRead<uint32_t>(dataPtr, length, isBigEndian);
+
+    switch (service_id) {
+        case DLT_SERVICE_ID_GET_LOG_INFO:
+        {
+            GetLogInfo msg;
+            msg.status = dltPayloadRead<uint8_t>(dataPtr, length, isBigEndian);
+            if ((msg.status != 6) && (msg.status != 7)) {
+                return msg;
+            }
+
+            const auto numApps = dltPayloadRead<uint16_t>(dataPtr, length, isBigEndian);
+            for (uint16_t i = 0; i < numApps; i++) {
+                GetLogInfo::App app;
+                app.id = asQString(dltPayloadReadId(dataPtr, length));
+                const uint16_t numCtx = dltPayloadRead<uint16_t>(dataPtr, length, isBigEndian);
+                for (uint16_t j = 0; j < numCtx; j++) {
+                    GetLogInfo::App::Ctx ctx;
+                    ctx.id = asQString(dltPayloadReadId(dataPtr, length));
+                    ctx.logLevel = dltPayloadRead<int8_t>(dataPtr, length, isBigEndian);
+                    ctx.traceStatus = dltPayloadRead<int8_t>(dataPtr, length, isBigEndian);
+                    ctx.description = QString::fromStdString(dltPayloadReadString(dataPtr, length, isBigEndian));
+                    app.ctxs.push_back(std::move(ctx));
+                }
+                if (msg.status == 7) {
+                    app.description = QString::fromStdString(dltPayloadReadString(dataPtr, length, isBigEndian));
+                }
+                msg.apps.push_back(std::move(app));
+            }
+            return msg;
+        }
+        case DLT_SERVICE_ID_GET_SOFTWARE_VERSION:
+        {
+            GetSoftwareVersion msg;
+            msg.version = dltPayloadReadString(dataPtr, length, isBigEndian);
+            return msg;
+        }
+        case DLT_SERVICE_ID_GET_DEFAULT_LOG_LEVEL:
+        {
+            GetDefaultLogLevel msg;
+            msg.logLevel = dltPayloadRead<int8_t>(dataPtr, length, isBigEndian);
+            msg.status = dltPayloadRead<uint8_t>(dataPtr, length, isBigEndian);
+            return msg;
+        }
+        case DLT_SERVICE_ID_SET_LOG_LEVEL:
+        {
+            SetLogLevel msg;
+            msg.status = dltPayloadRead<uint8_t>(dataPtr, length, isBigEndian);
+            return msg;
+        }
+        case DLT_SERVICE_ID_TIMEZONE:
+        {
+            Timezone msg;
+            msg.status = dltPayloadRead<uint8_t>(dataPtr, length, isBigEndian);
+            msg.timezone = dltPayloadRead<int32_t>(dataPtr, length, isBigEndian);
+            msg.isDst = dltPayloadRead<uint8_t>(dataPtr, length, isBigEndian);
+            return msg;
+        }
+        case DLT_SERVICE_ID_UNREGISTER_CONTEXT:
+        {
+            UnregisterContext msg;
+            msg.status = dltPayloadRead<uint8_t>(dataPtr, length, isBigEndian);
+            msg.appid = asQString(dltPayloadReadId(dataPtr, length));
+            msg.ctxid = asQString(dltPayloadReadId(dataPtr, length));
+            return msg;
+        }
+    }
+
+    throw std::runtime_error("Unknown service type");
+}
+
+}

--- a/qdlt/qdltctrlmsg.h
+++ b/qdlt/qdltctrlmsg.h
@@ -1,6 +1,8 @@
 #ifndef QDLTCTRLMSG_H
 #define QDLTCTRLMSG_H
 
+#include "export_rules.h"
+
 #include <vector>
 #include <variant>
 
@@ -57,7 +59,7 @@ struct UnregisterContext {
 using Type = std::variant<GetLogInfo, GetSoftwareVersion, GetDefaultLogLevel, SetLogLevel, Timezone,
                           UnregisterContext>;
 
-Type parse(const QByteArray&, bool isBigEndian);
+QDLT_EXPORT Type parse(const QByteArray&, bool isBigEndian);
 
 } // namespace qdlt::msg::payload
 

--- a/qdlt/qdltctrlmsg.h
+++ b/qdlt/qdltctrlmsg.h
@@ -1,0 +1,71 @@
+#ifndef QDLTCTRLMSG_H
+#define QDLTCTRLMSG_H
+
+#include <vector>
+#include <variant>
+
+#include <QByteArray>
+#include <QString>
+
+
+namespace qdlt::msg::payload {
+
+struct GetLogInfo {
+    struct App {
+        struct Ctx {
+            QString id;
+            int8_t logLevel;
+            int8_t traceStatus;
+            QString description;
+        };
+
+        QString id;
+        QString description;
+        std::vector<Ctx> ctxs;
+    };
+
+    uint8_t status;
+    std::vector<App> apps;
+};
+
+struct GetSoftwareVersion {
+    std::string version;
+};
+
+struct GetDefaultLogLevel
+{
+    uint8_t logLevel;
+    uint8_t status;
+};
+
+struct SetLogLevel {
+    uint8_t status;
+};
+
+struct Timezone {
+    uint8_t status;
+    int32_t timezone;
+    uint8_t isDst;
+};
+
+struct UnregisterContext {
+    uint8_t status;
+    QString appid;
+    QString ctxid;
+};
+
+using Type = std::variant<GetLogInfo, GetSoftwareVersion, GetDefaultLogLevel, SetLogLevel, Timezone,
+                          UnregisterContext>;
+
+Type parse(const QByteArray&, bool isBigEndian);
+
+} // namespace qdlt::msg::payload
+
+// helper type for the visitor
+template<class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+// explicit deduction guide (not needed as of C++20)
+template<class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+#endif // QDLTCTRLMSG_H

--- a/qdlt/tests/CMakeLists.txt
+++ b/qdlt/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(test_dltmessagematcher
     test_dltmessagematcher.cpp
+    test_dltctrlmsg.cpp
 )
 target_link_libraries(
   test_dltmessagematcher
@@ -16,6 +17,7 @@ add_test(
 
 add_executable(test_dltoptmanager
     test_dltoptmanager.cpp
+    test_dltctrlmsg.cpp
 )
 
 target_link_libraries(

--- a/qdlt/tests/test_dltctrlmsg.cpp
+++ b/qdlt/tests/test_dltctrlmsg.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include <qdltctrlmsg.h>
+
+#include <QByteArray>
+
+TEST(CtrlPayload, parse) {
+    // this is real payload of a dlt control message which collect from dlt-daemon
+    const auto data = QByteArray::fromHex("030000000701005359530001004d475200ffff2200436f6e74657874206f66206d61696e20646c742073797374656d206d616e616765721200444c542053797374656d204d616e6167657272656d6f");
+
+    auto payload = qdlt::msg::payload::parse(data, false);
+
+    ASSERT_TRUE(std::holds_alternative<qdlt::msg::payload::GetLogInfo>(payload));
+    auto getLogInfo = std::get<qdlt::msg::payload::GetLogInfo>(payload);
+    EXPECT_EQ(getLogInfo.status, 7);
+    ASSERT_EQ(getLogInfo.apps.size(), 1);
+
+    auto app = getLogInfo.apps[0];
+    EXPECT_EQ(app.id, "SYS");
+    EXPECT_EQ(app.description, "DLT System Manager");
+    ASSERT_EQ(app.ctxs.size(), 1);
+
+    auto ctx = app.ctxs[0];
+    EXPECT_EQ(ctx.id, "MGR");
+    EXPECT_EQ(ctx.logLevel, '\xff');
+    EXPECT_EQ(ctx.traceStatus, '\xff');
+    EXPECT_EQ(ctx.description, "Context of main dlt system manager");
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,9 @@ add_executable(dlt-viewer
     searchform.cpp
     ${UI_RESOURCES_RCC}
     resources/dlt_viewer.rc
-    )
+    ecutree.h
+    ecutree.cpp
+)
 
 target_link_libraries(dlt-viewer
     qdlt

--- a/src/ecutree.cpp
+++ b/src/ecutree.cpp
@@ -1,0 +1,17 @@
+#include "ecutree.h"
+
+void EcuTree::add(const QString& ecuId, const qdlt::msg::payload::GetLogInfo& info)
+{
+    for (const auto& app : info.apps) {
+        App appData;
+        appData.description = app.description;
+        for (const auto& ctx : app.ctxs) {
+            Ctx ctxData;
+            ctxData.description = ctx.description;
+            ctxData.logLevel = ctx.logLevel;
+            ctxData.traceStatus = ctx.traceStatus;
+            appData.contexts[ctx.id] = std::move(ctxData);
+        }
+        ecus[ecuId][app.id] = std::move(appData);
+    }
+}

--- a/src/ecutree.h
+++ b/src/ecutree.h
@@ -1,0 +1,27 @@
+#ifndef ECUTREEBUILDER_H
+#define ECUTREEBUILDER_H
+
+#include <qdltctrlmsg.h>
+
+#include <map>
+
+struct EcuTree
+{
+    void add(const QString& ecuId, const qdlt::msg::payload::GetLogInfo&);
+
+    using EcuId = QString;
+    using AppId = QString;
+    using CtxId = QString;
+    struct Ctx {
+        QString description;
+        int8_t logLevel;
+        int8_t traceStatus;
+    };
+    struct App {
+        QString description;
+        std::map<CtxId, Ctx> contexts;
+    };
+    std::map<EcuId, std::map<AppId, App>> ecus;
+};
+
+#endif // ECUTREEBUILDER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -83,6 +83,7 @@ extern "C" {
 #include "tablemodel.h"
 #include "sortfilterproxymodel.h"
 #include "qdltoptmanager.h"
+#include "qdltctrlmsg.h"
 
 
 MainWindow::MainWindow(QWidget *parent) :
@@ -2060,8 +2061,9 @@ void MainWindow::reloadLogFileFinishFilter()
         // FIXME: this is slow operation running in the main loop
         QDltMsg msg;
         for (const auto msgIndex : msgIndexList) {
-            if (qfile.getMsg(msgIndex, msg))
+            if (qfile.getMsg(msgIndex, msg)) {
                 contextLoadingFile(msg);
+            }
         }
     }
 
@@ -4427,172 +4429,62 @@ void MainWindow::onSearchresultsTableSelectionChanged(const QItemSelection & sel
 
 void MainWindow::controlMessage_ReceiveControlMessage(EcuItem *ecuitem, const QDltMsg &msg)
 {
-    const char *ptr;
-    int32_t length;
+    auto ctrlMsg = qdlt::msg::payload::parse(msg.getPayload(), msg.getEndianness() == QDlt::DltEndiannessBigEndian);
+    std::visit(overloaded{[&](const qdlt::msg::payload::GetSoftwareVersion &) {
+                              // TODO: use parsed payload
+                              // check if plugin autoload enabled and version string not already parsed
+                              if(!autoloadPluginsVersionEcus.contains(msg.getEcuid()))
+                              {
+                                  versionString(msg);
+                                  autoloadPluginsVersionEcus.append(msg.getEcuid());
+                              }
+                          },
+                          [&](const qdlt::msg::payload::GetLogInfo &payload) {
+                              if (payload.status == 8)
+                              {
+                                  ecuitem->InvalidAll();
+                              }
 
-    QByteArray payload = msg.getPayload();
-    ptr = payload.constData();
-    length = payload.size();
-
-    /* control message was received */
-    uint32_t service_id_tmp=0;
-    DLT_MSG_READ_VALUE(service_id_tmp,ptr,length,uint32_t);
-    uint32_t service_id=DLT_ENDIAN_GET_32( ((msg.getEndianness()==QDlt::DltEndiannessBigEndian)?DLT_HTYP_MSBF:0), service_id_tmp);
-
-    switch (service_id)
-    {
-    case DLT_SERVICE_ID_GET_SOFTWARE_VERSION:
-    {
-        // check if plugin autoload enabled and version string not already parsed
-        if(!autoloadPluginsVersionEcus.contains(msg.getEcuid()))
-        {
-            versionString(msg);
-            autoloadPluginsVersionEcus.append(msg.getEcuid());
-        }
-        break;
-    }
-    case DLT_SERVICE_ID_GET_LOG_INFO:
-    {
-        /* Only status 1,2,6,7,8 is supported yet! */
-
-        uint8_t status=0;
-        DLT_MSG_READ_VALUE(status,ptr,length,uint8_t); /* No endian conversion necessary */
-
-        /* Support for status=8 */
-        if (status==8)
-        {
-            ecuitem->InvalidAll();
-        }
-
-        /* Support for status=6 and status=7 */
-        if ((status==6) || (status==7))
-        {
-            uint16_t count_app_ids=0,count_app_ids_tmp=0;
-            DLT_MSG_READ_VALUE(count_app_ids_tmp,ptr,length,uint16_t);
-            count_app_ids=DLT_ENDIAN_GET_16(((msg.getEndianness()==QDlt::DltEndiannessBigEndian)?DLT_HTYP_MSBF:0), count_app_ids_tmp);
-            for (int32_t num=0;num<count_app_ids;num++)
-            {
-                char apid[DLT_ID_SIZE+1];
-                apid[DLT_ID_SIZE] = 0;
-
-                DLT_MSG_READ_ID(apid,ptr,length);
-
-                uint16_t count_context_ids=0,count_context_ids_tmp=0;
-                DLT_MSG_READ_VALUE(count_context_ids_tmp,ptr,length,uint16_t);
-                count_context_ids=DLT_ENDIAN_GET_16(((msg.getEndianness()==QDlt::DltEndiannessBigEndian)?DLT_HTYP_MSBF:0), count_context_ids_tmp);
-
-                for (int32_t num2=0;num2<count_context_ids;num2++)
-                {
-                    QString contextDescription;
-                    char ctid[DLT_ID_SIZE+1];
-                    ctid[DLT_ID_SIZE] = 0;
-
-                    DLT_MSG_READ_ID(ctid,ptr,length);
-
-                    int8_t log_level=0;
-                    DLT_MSG_READ_VALUE(log_level,ptr,length,int8_t); /* No endian conversion necessary */
-
-                    int8_t trace_status=0;
-                    DLT_MSG_READ_VALUE(trace_status,ptr,length,int8_t); /* No endian conversion necessary */
-
-                    if (status==7)
-                    {
-                        uint16_t context_description_length=0,context_description_length_tmp=0;
-                        DLT_MSG_READ_VALUE(context_description_length_tmp,ptr,length,uint16_t);
-                        context_description_length=DLT_ENDIAN_GET_16(((msg.getEndianness()==QDlt::DltEndiannessBigEndian)?DLT_HTYP_MSBF:0),context_description_length_tmp);
-
-                        if (length<context_description_length)
-                        {
-                            length = -1;
-                        }
-                        else
-                        {
-                            contextDescription = QString(QByteArray((char*)ptr,context_description_length));
-                            ptr+=context_description_length;
-                            length-=context_description_length;
-                        }
-                    }
-
-                    controlMessage_SetContext(ecuitem,QString(apid),QString(ctid),contextDescription,log_level,trace_status);
-                }
-
-                if (status==7)
-                {
-                    QString applicationDescription;
-                    uint16_t application_description_length=0,application_description_length_tmp=0;
-                    DLT_MSG_READ_VALUE(application_description_length_tmp,ptr,length,uint16_t);
-                    application_description_length=DLT_ENDIAN_GET_16(((msg.getEndianness()==QDlt::DltEndiannessBigEndian)?DLT_HTYP_MSBF:0),application_description_length_tmp);
-                    applicationDescription = QString(QByteArray((char*)ptr,application_description_length));
-                    controlMessage_SetApplication(ecuitem,QString(apid),applicationDescription);
-                    ptr+=application_description_length;
-                }
-            }
-        }
-
-        break;
-    }
-    case DLT_SERVICE_ID_GET_DEFAULT_LOG_LEVEL:
-    {
-        uint8_t status=0;
-        DLT_MSG_READ_VALUE(status,ptr,length,uint8_t); /* No endian conversion necessary */
-
-        uint8_t loglevel=0;
-        DLT_MSG_READ_VALUE(loglevel,ptr,length,uint8_t); /* No endian conversion necessary */
-
-        switch (status)
-        {
-        case 0: /* OK */
-        {
-            ecuitem->loglevel = loglevel;
-            ecuitem->status = EcuItem::valid;
-        }
-            break;
-        case 1: /* NOT_SUPPORTED */
-        {
-            ecuitem->status = EcuItem::unknown;
-        }
-            break;
-        case 2: /* ERROR */
-        {
-            ecuitem->status = EcuItem::invalid;
-        }
-            break;
-        }
-        /* update status */
-        ecuitem->update();
-
-        break;
-    }
-    case DLT_SERVICE_ID_SET_LOG_LEVEL:
-    {
-        break;
-    }
-    case DLT_SERVICE_ID_TIMEZONE:
-    {
-        if(payload.size() == sizeof(DltServiceTimezone))
-        {
-            DltServiceTimezone *service;
-            service = (DltServiceTimezone*) payload.constData();
-
-            if(msg.getEndianness() == QDlt::DltEndiannessLittleEndian)
-                controlMessage_Timezone(service->timezone, service->isdst);
-            else
-                controlMessage_Timezone(DLT_SWAP_32(service->timezone), service->isdst);
-        }
-        break;
-    }
-    case DLT_SERVICE_ID_UNREGISTER_CONTEXT:
-    {
-        if(payload.size() == sizeof(DltServiceUnregisterContext))
-        {
-            DltServiceUnregisterContext *service;
-            service = (DltServiceUnregisterContext*) payload.constData();
-
-            controlMessage_UnregisterContext(msg.getEcuid(),QDltMsg::getStringFromId(service->apid),QDltMsg::getStringFromId(service->ctid));
-        }
-        break;
-    }
-    } // switch
+                              if (payload.status == 6 || payload.status == 7) {
+                                  for (const auto &app : payload.apps) {
+                                      for (const auto& ctx : app.ctxs) {
+                                          controlMessage_SetContext(ecuitem, app.id, ctx.id,
+                                          ctx.description, ctx.logLevel,
+                                          ctx.traceStatus);
+                                      }
+                                      if (payload.status == 7) {
+                                          controlMessage_SetApplication(ecuitem, app.id,
+                                          app.description);
+                                      }
+                                  }
+                              }
+                          },
+                          [&](const qdlt::msg::payload::GetDefaultLogLevel &payload) {
+                              switch (payload.status) {
+                              case 0: /* OK */
+                                  ecuitem->loglevel = payload.logLevel;
+                                  ecuitem->status = EcuItem::valid;
+                                  break;
+                              case 1: /* NOT_SUPPORTED */
+                                  ecuitem->status = EcuItem::unknown;
+                                  break;
+                              case 2: /* ERROR */
+                                  ecuitem->status = EcuItem::invalid;
+                                  break;
+                              }
+                              ecuitem->update();
+                          },
+                          [&](const qdlt::msg::payload::Timezone &payload) {
+                              controlMessage_Timezone(payload.timezone, payload.isDst);
+                          },
+                          [&](const qdlt::msg::payload::UnregisterContext &payload) {
+                              controlMessage_UnregisterContext(msg.getEcuid(), payload.appid,
+                              payload.ctxid);
+                          },
+                          [&](const qdlt::msg::payload::SetLogLevel &) {
+                              // nothing to do
+                          }},
+               ctrlMsg);
 }
 
 void MainWindow::controlMessage_SendControlMessage(EcuItem* ecuitem,DltMessage &msg, QString appid, QString contid)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -96,6 +96,8 @@ namespace Ui {
     class MainWindow;
 }
 
+struct EcuTree;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -236,13 +238,8 @@ private:
 
     void getSelectedItems(EcuItem **ecuitem,ApplicationItem** appitem,ContextItem** conitem);
 
-    /**
-        * @brief Reload the complete log file
-        * @param update if this parameter is false, the file is loaded the first time, if true the reload is performed because of a changed configuration
-        *
-        */
-    void reloadLogFileStop();
     void reloadLogFile(bool update=false, bool multithreaded = true);
+    void populateEcusTree(EcuTree&& ecuTree);
 
     void reloadLogFileDefaultFilter();
 
@@ -275,7 +272,6 @@ private:
     void updatePluginsECUList();
     void updatePlugins();
     void updatePlugin(PluginItem *item);
-    void contextLoadingFile(const QDltMsg &msg);
     void versionString(const QDltMsg &msg);
     void pluginsAutoload(QString version);
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -149,6 +149,7 @@ SOURCES += main.cpp \
     dltmsgqueue.cpp \
     dltfileindexerthread.cpp \
     dltfileindexerdefaultfilterthread.cpp \
+    ecutree.cpp \
 
 # Show these headers in the project
 HEADERS += mainwindow.h \
@@ -180,7 +181,8 @@ HEADERS += mainwindow.h \
     dltmsgqueue.h \
     dltfileindexerthread.h \
     dltfileindexerdefaultfilterthread.h \
-    mcudpsocket.h
+    mcudpsocket.h \
+    ecutree.h \
 
 # Compile these UI files
 FORMS += mainwindow.ui \


### PR DESCRIPTION
This PR resolves https://github.com/COVESA/dlt-viewer/issues/576 for the cases when DLT log contains lots of apps and contexts. 

Historically, the same function used to populate ECU tree (in the "Config"-tab) both in online and offline modes. This was a problem for offline mode (aka dlt-file loading), because UI update is then called multiple time in a short time frame ate the end of file processing freezing the whole app. The fix is to:
1. Separate parsing of control messages payloads from UI creation
2. When tree view is created use more efficient constructors, which do not force many redundant UI updates.
