### PR TITLE
Fix performance issue with online tracing.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1358,7 +1358,7 @@ void MainWindow::appendDltFile(const QString &fileName)
     }
 
     /* read DLT messages and append to current output file */
-    if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
+    if(!outputfile.isOpen() && !outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
     {
         qDebug() << "Failed opening WriteOnly" << outputfile.fileName();
         return;
@@ -1410,7 +1410,7 @@ void MainWindow::on_action_menuFile_Import_DLT_Stream_triggered()
     dlt_file_open(&importfile,fileName.toLatin1(),0);
 
     /* parse and build index of complete log file and show progress */
-    if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
+    if(!outputfile.isOpen() && !outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
     {
         qDebug() << "Failed opening WriteOnly" << outputfile.fileName();
         return;
@@ -1453,7 +1453,7 @@ void MainWindow::on_action_menuFile_Import_DLT_Stream_with_Serial_Header_trigger
     dlt_file_open(&importfile,fileName.toLatin1(),0);
 
     /* parse and build index of complete log file and show progress */
-    if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
+    if(!outputfile.isOpen() && !outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
     {
         qDebug() << "Failed opening WriteOnly" << outputfile.fileName();
         return;
@@ -3930,7 +3930,8 @@ void MainWindow::writeDLTMessageToFile(const QByteArray& bufferHeader, std::stri
         dlt_set_id(str.ecu, ecuitem->id.toLatin1());
 
     /* check if message is matching the filter */
-    if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
+    // open the outputfile, if it is not open yet
+    if(!outputfile.isOpen() && !outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
     {
         qDebug() << "Failed opening WriteOnly" << outputfile.fileName();
     }
@@ -3973,7 +3974,7 @@ void MainWindow::writeDLTMessageToFile(const QByteArray& bufferHeader, std::stri
     outputfile.write(bufferHeader);
     outputfile.write(payload.data(), payload.size());
     outputfile.flush();
-    outputfile.close();
+    //outputfile.close();  // This slows down online tracing, keep open while online tracing
 }
 
 void MainWindow::read(EcuItem* ecuitem)
@@ -4691,7 +4692,7 @@ void MainWindow::controlMessage_SendControlMessage(EcuItem* ecuitem,DltMessage &
     }
 
     /* Skip the file handling, if indexer is working on the file */
-    if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
+    if(!outputfile.isOpen() && !outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
     {
         qDebug() << "Failed opening WriteOnly" << outputfile.fileName();
         return;
@@ -4710,7 +4711,7 @@ void MainWindow::controlMessage_SendControlMessage(EcuItem* ecuitem,DltMessage &
 
         dltIndexer->unlock();
     }
-    outputfile.close();
+    //outputfile.close();  // This slows down online tracing, keep open while online tracing
 
 }
 
@@ -4766,7 +4767,7 @@ void MainWindow::controlMessage_WriteControlMessage(DltMessage &msg, QString app
     msg.standardheader->len = DLT_HTOBE_16(msg.headersize - sizeof(DltStorageHeader) + msg.datasize);
 
     /* Skip the file handling, if indexer is working on the file */
-    if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
+    if(!outputfile.isOpen() && !outputfile.open(QIODevice::WriteOnly|QIODevice::Append))
     {
         qDebug() << "Failed opening WriteOnly" << outputfile.fileName();
         return;
@@ -4787,7 +4788,7 @@ void MainWindow::controlMessage_WriteControlMessage(DltMessage &msg, QString app
 
         dltIndexer->unlock();
     }
-    outputfile.close();
+    //outputfile.close();  // This slows down online tracing, keep open while online tracing
 }
 
 void MainWindow::on_action_menuDLT_Get_Default_Log_Level_triggered()


### PR DESCRIPTION
Keep outputfile open, when first DLT message was written. Issue was introduced with 2024-01-31 feature opening ReadOnly DLT files.