### PR TITLE
Persist Search History

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -166,10 +166,12 @@ private:
     QStringList autoloadPluginsVersionStrings;
 
     /* String List Containing Search History */
-    enum { MaxSearchHistory = 50 };
+    enum { MaxSearchHistory = 20 };
     QAction *searchHistoryActs[MaxSearchHistory];
     QStringList searchHistory;
-
+    QLineEdit* searchLineEdit;
+    QComboBox* searchComboBox;
+    QCompleter* searchCompleter;
 
     /* Recent files */
     enum { MaxRecentFiles = 5 };
@@ -596,6 +598,7 @@ public slots:
     //History Slots
     void onAddActionToHistory();
     void onSearchProgressChanged(bool isInProgress);
+    void loadSearchHistoryList(QStringList &searchHistory);
 
     void handleImportResults(const QString &);
     void handleExportResults(const QString &);

--- a/src/searchdialog.cpp
+++ b/src/searchdialog.cpp
@@ -618,6 +618,18 @@ void SearchDialog::clearCacheHistory()
     cachedHistoryKey.clear();
 }
 
+void SearchDialog::saveSearchHistory(QStringList& searchHistory) {
+    //To save the search history
+    QSettings settings("MyApp", "SearchHistory");
+    settings.beginWriteArray("history");
+    int count = qMin(searchHistory.size(), 20);
+    for (int i = 0; i < count; ++i) {
+        settings.setArrayIndex(i);
+        settings.setValue("entry", searchHistory.at(i));
+    }
+    settings.endArray();
+}
+
 void SearchDialog::on_checkBoxHeader_toggled(bool checked)
 {
    QDltSettingsManager::getInstance()->setValue("other/search/checkBoxHeader", checked);

--- a/src/searchdialog.h
+++ b/src/searchdialog.h
@@ -158,6 +158,7 @@ public slots:
     void findPreviousClicked();
     void loadSearchHistory();
     void abortSearch();
+    void saveSearchHistory(QStringList &searchHistory);
 
 signals:
     void refreshedSearchIndex();

--- a/src/searchform.cpp
+++ b/src/searchform.cpp
@@ -29,6 +29,11 @@ QLineEdit *SearchForm::input() const
     return ui->comboBox->lineEdit();
 }
 
+QComboBox *SearchForm::getComboBox() const
+{
+    return ui->comboBox;
+}
+
 void SearchForm::setState(State state)
 {
     switch(state) {

--- a/src/searchform.h
+++ b/src/searchform.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include <QStringListModel>
+#include <QComboBox>
 
 namespace Ui {
 class SearchForm;
@@ -30,6 +31,7 @@ public:
     void setProgress(int val);
     void resetProgress();
     void updateHistory();
+    QComboBox* getComboBox() const;
 
 signals:
     void abortSearch();


### PR DESCRIPTION
Persist the search history even across DLT Viewer restarts.

Signed-off by : Pavithra Anand <Pavithra.AA.Anand@partner.bmwgroup.com>