### PR TITLE
fix: use fromLatin1 for string args with ascii encoding

### DIFF
--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -391,12 +391,12 @@ QString QDltArgument::toString(bool binary) const
         break;
     case DltTypeInfoStrg:
         if(data.size()) {
-            text += QString::fromLatin1(data.data());
+            text += QString::fromLatin1(data);
         }
         break;
     case DltTypeInfoUtf8:
         if(data.size()) {
-            text += QString::fromUtf8(data.data());
+            text += QString::fromUtf8(data);
         }
         break;
     case DltTypeInfoBool:
@@ -533,12 +533,12 @@ QVariant QDltArgument::getValue() const
         break;
     case DltTypeInfoStrg:
         if(data.size()) {
-            return QVariant(QString(getData()));
+            return QVariant(QString::fromLatin1(data));
         }
         break;
     case DltTypeInfoUtf8:
         if(data.size()) {
-            return QVariant(QString::fromUtf8(data.data()));
+            return QVariant(QString::fromUtf8(data));
         }
         break;
     case DltTypeInfoBool:
@@ -646,7 +646,7 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
         return true;
     case QVariant::String:
         data = value.toByteArray();
-        typeInfo = QDltArgument::DltTypeInfoStrg;
+        typeInfo = QDltArgument::DltTypeInfoUtf8;
         return true;
     case QVariant::Bool:
         {

--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -391,7 +391,7 @@ QString QDltArgument::toString(bool binary) const
         break;
     case DltTypeInfoStrg:
         if(data.size()) {
-            text += QString("%1").arg(QString(getData()));
+            text += QString::fromLatin1(data.data());
         }
         break;
     case DltTypeInfoUtf8:


### PR DESCRIPTION
The default QString constructor uses internally fromUtf8 which is wrong for strings that claim to be ascii encoded.

Issue: #638