### PR TITLE
tests: add unit test for QDltArgument

### DIFF
--- a/qdlt/tests/CMakeLists.txt
+++ b/qdlt/tests/CMakeLists.txt
@@ -31,3 +31,19 @@ add_test(
   NAME test_dltoptmanager
   COMMAND $<TARGET_FILE:test_dltoptmanager>
 )
+
+add_executable(test_qdltargument
+    test_qdltargument.cpp
+)
+
+target_link_libraries(
+  test_qdltargument
+  PRIVATE
+    GTest::gtest_main
+    qdlt
+)
+
+add_test(
+  NAME test_qdltargument
+  COMMAND $<TARGET_FILE:test_qdltargument>
+)

--- a/qdlt/tests/test_qdltargument.cpp
+++ b/qdlt/tests/test_qdltargument.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <qdltargument.h>
+
+TEST(QDltArgument, constructor) {
+    QDltArgument arg;
+
+    ASSERT_EQ(arg.getTypeInfo(), QDltArgument::DltTypeInfoUnknown);
+    ASSERT_EQ(arg.getTypeInfoString(), QString{});
+    ASSERT_EQ(arg.getDataSize(), 0);
+    ASSERT_EQ(arg.toString(), QString("?")); // a bit weird for data size 0
+    ASSERT_EQ(arg.getValue(), QVariant());
+}
+
+TEST(QDltArgument, string_ascii) {
+    QDltArgument arg;
+    arg.setTypeInfo(QDltArgument::DltTypeInfoStrg);
+    const unsigned char asc_data[] = {
+        0xc3, 0xbc, 'b', 'e' // Ã¼be (and not übe)
+    };
+    arg.setData(QByteArray::fromRawData((const char*)asc_data, sizeof(asc_data)));
+    ASSERT_EQ(arg.toString(), QString::fromUtf8("Ã¼be"));
+
+    // parse from raw payload
+    const unsigned char asc_data2[] = {0x00, 0x02, 0x00, 0x00, // type info
+                                       0x04, 0x00,             // str len
+                                       0xc3, 0xbc, 'b',  'e'};
+    QByteArray payload = QByteArray::fromRawData((const char*)asc_data2, sizeof(asc_data2));
+    unsigned int offset = 0;
+    arg.setArgument(payload, offset, QDlt::DltEndiannessLittleEndian);
+    ASSERT_EQ(arg.getTypeInfo(), QDltArgument::DltTypeInfoStrg);
+    ASSERT_EQ(arg.getDataSize(), 4);
+    ASSERT_EQ(arg.toString().length(), 4);
+    ASSERT_EQ(arg.toString(), QString::fromUtf8("Ã¼be"));
+    ASSERT_EQ(arg.toString(true), QString{"c3 bc 62 65"});
+    ASSERT_EQ(arg.getValue(), QVariant(QString::fromUtf8("Ã¼be")));
+}
+
+TEST(QDltArgument, string_utf8) {
+    QDltArgument arg;
+    arg.setTypeInfo(QDltArgument::DltTypeInfoUtf8);
+    const unsigned char asc_data[] = {
+        0xc3, 0xbc, 'b', 'e' // übe
+    };
+    arg.setData(QByteArray::fromRawData((const char*)asc_data, sizeof(asc_data)));
+    ASSERT_EQ(arg.toString(), QString::fromUtf8((const char*)asc_data, sizeof(asc_data)));
+
+    // parse from raw payload
+    const unsigned char asc_data2[] = {0x00, 0x82, 0x00, 0x00, // type info
+                                       0x04, 0x00,             // str len
+                                       0xc3, 0xbc, 'b',  'e'};
+    QByteArray payload = QByteArray::fromRawData((const char*)asc_data2, sizeof(asc_data2));
+    unsigned int offset = 0;
+    arg.setArgument(payload, offset, QDlt::DltEndiannessLittleEndian);
+    ASSERT_EQ(arg.getTypeInfo(), QDltArgument::DltTypeInfoUtf8);
+    ASSERT_EQ(arg.getDataSize(), 4);
+    ASSERT_EQ(arg.toString().length(), 3);
+    ASSERT_EQ(arg.toString(), QString::fromUtf8("übe"));
+    ASSERT_EQ(arg.toString(true), QString{"c3 bc 62 65"});
+    ASSERT_EQ(arg.getValue(), QVariant(QString::fromUtf8("übe")));
+}
+
+TEST(QDltArgument, setValueString) {
+    QDltArgument arg;
+    ASSERT_EQ(arg.setValue(QVariant(QString{"übe"})), true);
+    // this should be a type utf8 string and not ascii:
+    ASSERT_EQ(arg.getTypeInfo(), QDltArgument::DltTypeInfoUtf8);
+    ASSERT_EQ(arg.getDataSize(), 4);
+    ASSERT_EQ(arg.toString(), QString::fromUtf8("übe"));
+    ASSERT_EQ(arg.getValue(), QVariant(QString::fromUtf8("übe")));
+}


### PR DESCRIPTION
Add first unit tests for QDltArgument class focussing on utf8/ascii strings.