### PR TITLE
Avoid exception when parsing uninteresting control message

### DIFF
--- a/qdlt/qdltctrlmsg.cpp
+++ b/qdlt/qdltctrlmsg.cpp
@@ -77,9 +77,9 @@ Type parse(const QByteArray& data, bool isBigEndian)
     int32_t length = data.length();
     const char *dataPtr = data.data();
 
-    auto service_id = dltPayloadRead<uint32_t>(dataPtr, length, isBigEndian);
+    auto serviceId = dltPayloadRead<uint32_t>(dataPtr, length, isBigEndian);
 
-    switch (service_id) {
+    switch (serviceId) {
         case DLT_SERVICE_ID_GET_LOG_INFO:
         {
             GetLogInfo msg;
@@ -145,7 +145,7 @@ Type parse(const QByteArray& data, bool isBigEndian)
         }
     }
 
-    throw std::runtime_error("Unknown service type");
+    return Uninteresting{serviceId};
 }
 
 }

--- a/qdlt/qdltctrlmsg.h
+++ b/qdlt/qdltctrlmsg.h
@@ -56,8 +56,12 @@ struct UnregisterContext {
     QString ctxid;
 };
 
+struct Uninteresting {
+    uint32_t serviceId;
+};
+
 using Type = std::variant<GetLogInfo, GetSoftwareVersion, GetDefaultLogLevel, SetLogLevel, Timezone,
-                          UnregisterContext>;
+                          UnregisterContext, Uninteresting>;
 
 QDLT_EXPORT Type parse(const QByteArray&, bool isBigEndian);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4515,9 +4515,13 @@ void MainWindow::controlMessage_ReceiveControlMessage(EcuItem *ecuitem, const QD
                               controlMessage_UnregisterContext(msg.getEcuid(), payload.appid,
                               payload.ctxid);
                           },
-                          [&](const qdlt::msg::payload::SetLogLevel &) {
+                          [](const qdlt::msg::payload::SetLogLevel &) {
                               // nothing to do
-                          }},
+                          },
+                          [](const qdlt::msg::payload::Uninteresting& payload) {
+                              qDebug() << "Received control message with id: " << payload.serviceId;
+                          }
+               },
                ctrlMsg);
 }
 


### PR DESCRIPTION
Set of control messages used to figure out ECUs tree is a subset of all possible control messages. Regression has been introduced https://github.com/COVESA/dlt-viewer/commit/63c4f8cedee7b216602fbdb97ba6a47ca34f7315 due to thrown exception when uninteresting control message type is encountered. This change fixes the regression by not throwing an exception in parse-method. The method now returns "uninteresting"-payload.

See https://github.com/COVESA/dlt-viewer/discussions/642