### PR TITLE
Fix ECUs config tree when importing dlp

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2544,9 +2544,6 @@ bool MainWindow::openDlpFile(QString fileName)
         if(QDltOptManager::getInstance()->isCommandlineMode())
             // if dlt viewer started as converter or with plugin option load file non multithreaded
             reloadLogFile(false,false);
-        else
-            // normally load log file mutithreaded
-            reloadLogFile();
         return true;
     } else {
         return false;


### PR DESCRIPTION
This is a fix of regression introduced with
https://github.com/COVESA/dlt-viewer/commit/a7bd8af1fffc9711e535704183853bedbd8e1c14

The fix prevents running the indexer when importing dlp, otherwise indexer calls reloadLogFileFinishFilter which recreates empty ecu tree

https://github.com/COVESA/dlt-viewer/issues/667