### PR TITLE
Windows 2019 to latest

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -139,7 +139,7 @@ jobs:
       matrix:
         task: [ sdk ]
         qt: [ 5 ]
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -139,7 +139,7 @@ jobs:
       matrix:
         task: [ parser, sdk ]
         qt: [ 5 ]
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/build_config.bat
+++ b/build_config.bat
@@ -5,8 +5,8 @@ echo ************************************
 echo *** Setting up environment ***
 
 REM Currently tested combinations by Qt installation
-REM 5.15.2 msvc2019
-REM 6.7.3 msvc2019
+REM 5.15.2 msvc2022
+REM 6.7.3 msvc2022
 
 if "%QTNO%"=="" (
    set QTNO=6
@@ -21,15 +21,15 @@ if "%QTVER%"=="" (
 )
 
 if "%MSVC_VER%"=="" (
-    set MSVC_VER=2019
+    set MSVC_VER=2022
 )
 
-if exist "C:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VER%\Enterprise\VC\Auxiliary\Build" (
+if exist "C:\Program Files\Microsoft Visual Studio\%MSVC_VER%\Enterprise\VC\Auxiliary\Build" (
     REM Visual Studio Community Edition 2019
-	if "%MSVC_DIR%"=="" set "MSVC_DIR=C:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VER%\Enterprise\VC\Auxiliary\Build"
+	if "%MSVC_DIR%"=="" set "MSVC_DIR=C:\Program Files\Microsoft Visual Studio\%MSVC_VER%\Enterprise\VC\Auxiliary\Build"
 ) else (
     REM Vidual Studio Professional 2019
-	if "%MSVC_DIR%"=="" set "MSVC_DIR=C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build"
+	if "%MSVC_DIR%"=="" set "MSVC_DIR=C:\Program Files\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build"
 )
 
 echo Set QT directory for %QTVER% and %MSVC_VER%


### PR DESCRIPTION
Change windows 2019 to windows 2025. Will impact both PR and Release workflows.

This is due to Github no longer supporting Windows 2019