### PR TITLE
Restore string arg encoding 

### DIFF
--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -391,7 +391,7 @@ QString QDltArgument::toString(bool binary) const
         break;
     case DltTypeInfoStrg:
         if(data.size()) {
-            text += QString::fromLatin1(data.data());
+            text += QString("%1").arg(QString(getData()));
         }
         break;
     case DltTypeInfoUtf8:

--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -389,14 +389,13 @@ QString QDltArgument::toString(bool binary) const
     case DltTypeInfoUnknown:
         text += QString("?");
         break;
+    // for legacy reasons dlt-viewer does not make a difference between formally ASCII-only and UTF8 strings
+    // both are handled as UTF8-encoded
+    // see https://github.com/COVESA/dlt-viewer/issues/657
     case DltTypeInfoStrg:
-        if(data.size()) {
-            text += QString("%1").arg(QString(getData()));
-        }
-        break;
     case DltTypeInfoUtf8:
         if(data.size()) {
-            text += QString::fromUtf8(data.data());
+            text += QString::fromUtf8(data);
         }
         break;
     case DltTypeInfoBool:
@@ -532,13 +531,9 @@ QVariant QDltArgument::getValue() const
     case DltTypeInfoUnknown:
         break;
     case DltTypeInfoStrg:
-        if(data.size()) {
-            return QVariant(QString(getData()));
-        }
-        break;
     case DltTypeInfoUtf8:
         if(data.size()) {
-            return QVariant(QString::fromUtf8(data.data()));
+            return QVariant(QString::fromUtf8(data));
         }
         break;
     case DltTypeInfoBool:
@@ -646,7 +641,7 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
         return true;
     case QVariant::String:
         data = value.toByteArray();
-        typeInfo = QDltArgument::DltTypeInfoStrg;
+        typeInfo = QDltArgument::DltTypeInfoUtf8; // treat all strings as UTF-8 encoded
         return true;
     case QVariant::Bool:
         {

--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -391,12 +391,12 @@ QString QDltArgument::toString(bool binary) const
         break;
     case DltTypeInfoStrg:
         if(data.size()) {
-            text += QString::fromLatin1(data);
+            text += QString::fromLatin1(data.data());
         }
         break;
     case DltTypeInfoUtf8:
         if(data.size()) {
-            text += QString::fromUtf8(data);
+            text += QString::fromUtf8(data.data());
         }
         break;
     case DltTypeInfoBool:
@@ -533,12 +533,12 @@ QVariant QDltArgument::getValue() const
         break;
     case DltTypeInfoStrg:
         if(data.size()) {
-            return QVariant(QString::fromLatin1(data));
+            return QVariant(QString(getData()));
         }
         break;
     case DltTypeInfoUtf8:
         if(data.size()) {
-            return QVariant(QString::fromUtf8(data));
+            return QVariant(QString::fromUtf8(data.data()));
         }
         break;
     case DltTypeInfoBool:
@@ -646,7 +646,7 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
         return true;
     case QVariant::String:
         data = value.toByteArray();
-        typeInfo = QDltArgument::DltTypeInfoUtf8;
+        typeInfo = QDltArgument::DltTypeInfoStrg;
         return true;
     case QVariant::Bool:
         {

--- a/qdlt/tests/test_qdltargument.cpp
+++ b/qdlt/tests/test_qdltargument.cpp
@@ -14,26 +14,19 @@ TEST(QDltArgument, constructor) {
 
 TEST(QDltArgument, string_ascii) {
     QDltArgument arg;
-    arg.setTypeInfo(QDltArgument::DltTypeInfoStrg);
-    const unsigned char asc_data[] = {
-        0xc3, 0xbc, 'b', 'e' // Ã¼be (and not übe)
-    };
-    arg.setData(QByteArray::fromRawData((const char*)asc_data, sizeof(asc_data)));
-    ASSERT_EQ(arg.toString(), QString::fromUtf8("Ã¼be"));
-
     // parse from raw payload
-    const unsigned char asc_data2[] = {0x00, 0x02, 0x00, 0x00, // type info
+    const unsigned char payloadData[] = {0x00, 0x02, 0x00, 0x00, // type info
                                        0x04, 0x00,             // str len
                                        0xc3, 0xbc, 'b',  'e'};
-    QByteArray payload = QByteArray::fromRawData((const char*)asc_data2, sizeof(asc_data2));
+    QByteArray payload = QByteArray::fromRawData((const char*)payloadData, sizeof(payloadData));
     unsigned int offset = 0;
     arg.setArgument(payload, offset, QDlt::DltEndiannessLittleEndian);
     ASSERT_EQ(arg.getTypeInfo(), QDltArgument::DltTypeInfoStrg);
     ASSERT_EQ(arg.getDataSize(), 4);
-    ASSERT_EQ(arg.toString().length(), 4);
-    ASSERT_EQ(arg.toString(), QString::fromUtf8("Ã¼be"));
+    // argument type is DltTypeInfoStrg (aka ASCII), the data is interpreted as UTF-8 encoded
+    ASSERT_EQ(arg.toString(), QString::fromUtf8("übe"));
     ASSERT_EQ(arg.toString(true), QString{"c3 bc 62 65"});
-    ASSERT_EQ(arg.getValue(), QVariant(QString::fromUtf8("Ã¼be")));
+    ASSERT_EQ(arg.getValue(), QVariant(QString::fromUtf8("übe")));
 }
 
 TEST(QDltArgument, string_utf8) {


### PR DESCRIPTION
This is to address https://github.com/COVESA/dlt-viewer/issues/657

I partially reverted two commits (added recently for 2.28) that started to interpret string arguments with ASCII encoding (`DltTypeInfoStrg`) as Latin1-encoded strings. Previously, dlt-viewer interpreted the same way both ASCII and UTF8 args, both were assumed UTF8. This PR restores that legacy behavior that many users relied upon for years, even if it is not 100% correct.