### PR TITLE
Add StartupWMClass to .desktop launcher

### DIFF
--- a/src/resources/org.genivi.DLTViewer.desktop
+++ b/src/resources/org.genivi.DLTViewer.desktop
@@ -6,3 +6,4 @@ Exec=dlt-viewer %u
 Icon=org.genivi.DLTViewer
 Terminal=false
 Categories=Development;
+StartupWMClass=dlt-viewer


### PR DESCRIPTION
Added missing `StartupWMClass` to .desktop launcher file.
Fixes an issue with dash icon and pinning to favourites on Linux distros.
![Screenshot From 2025-06-26 10-15-04](https://github.com/user-attachments/assets/37e9d63c-98ca-4e39-bbad-9021520d060e)
![Screenshot From 2025-06-26 10-17-19](https://github.com/user-attachments/assets/32333020-f44a-463d-9f08-087f8c3cf1d7)
