### PR TITLE
Edit All Log Levels - Bug Fix

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2985,7 +2985,7 @@ void MainWindow::on_action_menuConfig_Context_Edit_triggered()
 void MainWindow::on_action_menuDLT_Edit_All_Log_Levels_triggered()
 {
 
-    MultipleContextDialog dlg(0,0);
+    MultipleContextDialog dlg(logLevel,traceStatus);
 
     if(dlg.exec())
     {
@@ -3041,6 +3041,9 @@ void MainWindow::on_action_menuDLT_Edit_All_Log_Levels_triggered()
 
                     conitem->loglevel = dlg.loglevel();
                     conitem->tracestatus = dlg.tracestatus();
+
+                    logLevel = conitem->loglevel + 1;
+                    traceStatus = conitem->tracestatus +1;
 
                     /* update context item */
                     conitem->update();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -236,6 +236,10 @@ private:
 
     QList<unsigned long int> selectedMarkerRows;
 
+    //values to carry the logLevel and traceStatus : Edit All Log Levels
+    int logLevel = 0;
+    int traceStatus = 0;
+
     /* functions called in constructor */
     void initState();
     void initView();


### PR DESCRIPTION
"EditAllLogLevels" was showing default as the latest state always. Now it will show latest change made by the user.

Signed-off by : Renu Priya Krishnamoorthy <RenuPriya.KA.Krishnamoorthy@bti.bmwgroup.com>