### PR TITLE
Export search results into DLT file

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1570,9 +1570,6 @@ void MainWindow::exportSelection(bool ascii = true,bool file = false,QDltExporte
     disconnect(&exporter,SIGNAL(clipboard(QString)),this,SLOT(clipboard(QString)));
 }
 
-/* Exports search results from the search table view to clipboard or file in various formats.
-   For clipboard operations: uses selected rows only.
-   For file export operations: always exports all rows. */
 void MainWindow::exportSelection_searchTable(QDltExporter::DltExportFormat format = QDltExporter::FormatClipboard, const QString& fileName)
 {
     const QModelIndexList list = ui->tableView_SearchIndex->selectionModel()->selectedRows();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -255,6 +255,7 @@ private:
     void reloadLogFileDefaultFilter();
 
     void exportSelection(bool ascii,bool file,QDltExporter::DltExportFormat format);
+    /* Exports search results from the search table view to clipboard or file in various formats. For clipboard operations: uses selected rows only and for file export operations: always exports all rows. */
     void exportSelection_searchTable(QDltExporter::DltExportFormat format, const QString& fileName = QString());
 
     void ControlServiceRequest(EcuItem* ecuitem, uint32_t service_id);


### PR DESCRIPTION
Export all found DLT messages of a search result into a DLT file and "Export in DLT Format" option is in the context menu of search result.

https://github.com/COVESA/dlt-viewer/issues/200

Signed-off by : Pavithra Anand <Pavithra.AA.Anand@bti.bmwgroup.com>