### PR TITLE
Replace x86_64 macOS build

### DIFF
--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        macos: [ macos-13 ]
+        macos: [ macos-latest-large ]
         abi: [ x86 ]
         xcode: [ Xcode_15.2 ]
         qt: [ 5 ]

--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        macos: [ macos-latest-large ]
+        macos: [ macos-15-intel ]
         abi: [ x86 ]
         xcode: [ Xcode_15.2 ]
         qt: [ 5 ]

--- a/.github/workflows/BuildPR.yml
+++ b/.github/workflows/BuildPR.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         macos: [ macos-15-intel ]
         abi: [ x86 ]
-        xcode: [ Xcode_15.2 ]
+        xcode: [ Xcode_26.0 ]
         qt: [ 5 ]
     steps:
       - name: Checkout


### PR DESCRIPTION
Replacing macOS 13 with macos-15-intel
Replaced xCode 15.2 with 26.0
macOS 13 runner is going EOL 12/4/25.
intel x86_64 will be EOL Fall 2027