### PR TITLE
Fix build warnings when compiling with Qt 6.11 and MinGW 13

### DIFF
--- a/commander/main.cpp
+++ b/commander/main.cpp
@@ -59,7 +59,8 @@ int main(int argc, char *argv[])
         {
             // open outputfile
             outputfile.setFileName(opt.getLogFiles()[0]);
-            outputfile.open(QIODevice::WriteOnly|QIODevice::Truncate);
+            if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Truncate))
+                qDebug() << "ERROR: Cannot open output file:" << outputfile.fileName();
             outputfile.close();
         }
     }

--- a/qdlt/dlt_common.c
+++ b/qdlt/dlt_common.c
@@ -754,7 +754,8 @@ int dlt_message_header_flags(DltMessage *msg,char *text,int textlength,int flags
     if ((flags & DLT_HEADER_SHOW_TIME) == DLT_HEADER_SHOW_TIME)
     {
         /* print received time */
-        timeinfo = localtime ((const time_t*)(&(msg->storageheader->seconds)));
+        time_t seconds_copy = msg->storageheader->seconds;
+        timeinfo = localtime(&seconds_copy);
 
         if (timeinfo!=0)
         {

--- a/qdlt/fieldnames.cpp
+++ b/qdlt/fieldnames.cpp
@@ -30,6 +30,7 @@ QString FieldNames::getName(Fields cn, QDltSettingsManager *settings)
         case 1:
              return QString("Apid Desc");
         }
+        [[fallthrough]];
     case ContextId:
         if(settings == NULL)
         {
@@ -41,6 +42,7 @@ QString FieldNames::getName(Fields cn, QDltSettingsManager *settings)
         case 1:
              return QString("Ctid Desc");
         }
+        [[fallthrough]];
     case SessionId:
         if(settings == NULL)
         {
@@ -52,6 +54,7 @@ QString FieldNames::getName(Fields cn, QDltSettingsManager *settings)
         case 1:
              return QString("SessionName");
         }
+        [[fallthrough]];
     case Type:
         return QString("Type");
     case Subtype:

--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -649,17 +649,17 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
 
     endianness = QDlt::DltEndiannessLittleEndian;
 
-    switch(value.type())
+    switch(value.typeId())
     {
-    case QVariant::ByteArray:
+    case QMetaType::QByteArray:
         data = value.toByteArray();
         typeInfo = QDltArgument::DltTypeInfoRawd;
         return true;
-    case QVariant::String:
+    case QMetaType::QString:
         data = value.toByteArray();
         typeInfo = QDltArgument::DltTypeInfoUtf8; // treat all strings as UTF-8 encoded
         return true;
-    case QVariant::Bool:
+    case QMetaType::Bool:
         {
         bool bvalue = value.toBool();
         unsigned char cvalue = bvalue;
@@ -667,43 +667,41 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-        break;
-    case QVariant::Int:
+    case QMetaType::Int:
         {
         int bvalue = value.toInt();
         data = QByteArray((const char*)&bvalue,sizeof(int));
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-    case QVariant::LongLong:
+    case QMetaType::LongLong:
         {
         long long bvalue = value.toLongLong();
         data = QByteArray((const char*)&bvalue,sizeof(long long));
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-    case QVariant::UInt:
+    case QMetaType::UInt:
         {
         unsigned int bvalue = value.toUInt();
         data = QByteArray((const char*)&bvalue,sizeof(int));
         typeInfo = QDltArgument::DltTypeInfoUInt;
         return true;
         }
-    case QVariant::ULongLong:
+    case QMetaType::ULongLong:
         {
         unsigned long long bvalue = value.toULongLong();
         data = QByteArray((const char*)&bvalue,sizeof(unsigned long long));
         typeInfo = QDltArgument::DltTypeInfoUInt;
         return true;
         }
-    case QVariant::Double:
+    case QMetaType::Double:
         {
-        double bvalue = value.toInt();
+        double bvalue = value.toDouble();
         data = QByteArray((const char*)&bvalue,sizeof(double));
         typeInfo = QDltArgument::DltTypeInfoFloa;
         return true;
         }
-        break;
     default:
         break;
     }

--- a/qdlt/qdltexporter.cpp
+++ b/qdlt/qdltexporter.cpp
@@ -282,7 +282,7 @@ bool QDltExporter::startExport()
             {
                 QFileInfo info(filename);
                 info.baseName();
-                QFile *file;
+                QFile *file = nullptr;
                 if(exportFormat == QDltExporter::FormatAscii)
                     file = new QFile(to.fileName()+"/"+info.baseName()+".txt");
                 else if(exportFormat == QDltExporter::FormatUTF8)
@@ -325,7 +325,7 @@ bool QDltExporter::startExport()
             {
                 QFileInfo info(filename);
                 info.baseName();
-                QFile *file;
+                QFile *file = nullptr;
                 file = new QFile(to.fileName()+"/"+info.baseName()+".dlt");
                 QDltFilterList *filterList = new QDltFilterList();
                 if(!filterList->LoadFilter(filename,true))

--- a/qdlt/qdltfile.cpp
+++ b/qdlt/qdltfile.cpp
@@ -1058,7 +1058,7 @@ void QDltFile::calculateTotalSizes()
                                          static_cast<quint8>(dltHeaderData[3]);
 
         // Validate message length
-        if (dltMessageLength == 0 || dltMessageLength > 65535 ||
+        if (dltMessageLength == 0 ||
             dltMessageLength > (msgDataSize - storageHeaderSize)) {
             msgSizeCache[msgIndex] = info;
             continue;

--- a/qdlt/qdltimporter.cpp
+++ b/qdlt/qdltimporter.cpp
@@ -806,7 +806,8 @@ DltStorageHeader QDltImporter::makeDltStorageHeader(std::optional<DltStorageHead
         result.seconds = static_cast<time_t>(ts->sec);
         result.microseconds = static_cast<int32_t>(ts->usec);
     } else {
-        if (struct timespec ts; timespec_get(&ts, TIME_UTC)) {
+        struct timespec ts;
+        if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
             result.seconds = static_cast<uint32_t>(ts.tv_sec);
             result.microseconds = static_cast<int32_t>(ts.tv_nsec / 1000);
         } else {

--- a/qdlt/qdltmsg.cpp
+++ b/qdlt/qdltmsg.cpp
@@ -28,6 +28,7 @@ extern "C"
 
 #include <QtEndian>
 #include <QDateTime>
+#include <QTimeZone>
 #include <QCache>
 #include <QHash>
 
@@ -271,7 +272,7 @@ QString QDltMsg::getGmTimeWithOffsetString(qlonglong offset, bool dst)
     if(!date.isValid() || !time.isValid())
         return QString("Invalid date");
 
-    QDateTime gmDateTime(date,time,Qt::UTC);
+    QDateTime gmDateTime(date, time, QTimeZone::utc());
 
     gmDateTime = gmDateTime.addSecs(offset);
 
@@ -439,7 +440,7 @@ bool QDltMsg::setMsg(const QByteArray& buf, bool withStorageHeader,bool supportD
     DltStandardHeaderExtra headerextra;
     unsigned int extra_size,headersize,datasize;
     int sizeStorageHeader = 0;
-    quint32 storageHeaderTimestampNanoseconds = 0;
+    quint32 storageHeaderTimestampNanoseconds = 0; Q_UNUSED(storageHeaderTimestampNanoseconds)
     quint64 storageHeaderTimestampSeconds = 0;
     QString storageHeaderEcuId;
 

--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -137,7 +137,7 @@ void QDltOptManager::parse(const QStringList& args)
 
     if (m_parser.optionNames().isEmpty() && m_parser.positionalArguments().size() == 1)
     {
-        const QString& arg = m_parser.positionalArguments().at(0);
+        const QString arg = m_parser.positionalArguments().at(0);
         bool closeConsole = false;
         if(arg.endsWith(".dlp") || arg.endsWith(".DLP"))
         {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -88,9 +88,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow),
     timer(this),
     qcontrol(this),
+    crlfFilterWindow(nullptr),
     pulseButtonColor(255, 40, 40),
-    isSearchOngoing(false),
-    crlfFilterWindow(nullptr)
+    isSearchOngoing(false)
 {
 
     dltIndexer = NULL;
@@ -7945,7 +7945,8 @@ void MainWindow::onActionMenuConfigSaveAllECUsTriggered()
 {
     QString filename = QFileDialog::getSaveFileName(this, tr("Save DLT Filters"), workingDirectory.getDltDirectory(), tr("Save APID/CTID list (*.csv);;All files (*.*)"));
     QFile asciiFile(filename);
-    asciiFile.open(QIODevice::WriteOnly);
+    if(!asciiFile.open(QIODevice::WriteOnly))
+        return;
 
     // go over ECU Items
     for(int num = 0; num < project.ecu->topLevelItemCount (); num++)

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -63,7 +63,7 @@ void PluginTreeWidget::decreasePluginPriority(int index)
 void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 {
     const QTreeWidgetItem* dragged_item = this->currentItem();
-    const QTreeWidgetItem* target_item = this->itemAt(event->pos());
+    const QTreeWidgetItem* target_item = this->itemAt(event->position().toPoint());
 
     // Ignore event if moving over a child item
     if(dragged_item == nullptr || dragged_item->parent() != nullptr || (target_item != nullptr && target_item->parent() != nullptr)){
@@ -78,7 +78,7 @@ void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 void PluginTreeWidget::dropEvent(QDropEvent *event)
 {
     QTreeWidgetItem* dragged_item = this->currentItem();
-    const QTreeWidgetItem* target_item = this->itemAt(event->pos());
+    const QTreeWidgetItem* target_item = this->itemAt(event->position().toPoint());
 
     // Avoid dropping children
     // Allow drop only over top level items (or at the end)

--- a/src/resources/dlt_viewer.rc
+++ b/src/resources/dlt_viewer.rc
@@ -1,7 +1,7 @@
 // MSVC, Windows SDK
 #if defined(_WIN32)
 
-IDI_ICON1               ICON    DISCARDABLE     "icon\org.genivi.DLTViewer.ico"
+IDI_ICON1               ICON    DISCARDABLE     "icon/org.genivi.DLTViewer.ico"
 
 #include "../version.h"
 

--- a/src/sortfilterproxymodel.cpp
+++ b/src/sortfilterproxymodel.cpp
@@ -75,7 +75,8 @@ EcuIdFilterProxyModel::EcuIdFilterProxyModel(QObject *parent)
 // Sets a single ECU ID for filtering
 void EcuIdFilterProxyModel::setEcuId(const QString& ecuId) {
     ecu = ecuId;
-    this->invalidateFilter();
+    beginFilterChange();
+    endFilterChange();
 }
 
 
@@ -85,14 +86,16 @@ void EcuIdFilterProxyModel::setEcuIdList(const QSet<QString>& ids) {
     ecuIdList.clear();
     for (const QString& id : ids)
         ecuIdList.insert(id.trimmed().toLower());
-    invalidateFilter();
+    beginFilterChange();
+    endFilterChange();
     sort(-1);
 }
 
 // Sets the column index for ECU filtering
 void EcuIdFilterProxyModel::setEcuColumn(int column) {
     ecuColumn = column;
-    this->invalidateFilter();
+    beginFilterChange();
+    endFilterChange();
 }
 
 //Determines if a row should be accepted based on ECU filtering


### PR DESCRIPTION
## Summary

This PR fixes all compiler warnings when building with Qt 6.11.0 and MinGW 13.1.0 on Windows.

### Changes

- **qdltimporter.cpp** — Replace `timespec_get`/`TIME_UTC` with `clock_gettime(CLOCK_REALTIME)` for MinGW compatibility
- **qdltargument.cpp** — Replace deprecated `QVariant::type()` with `typeId()` and update case labels to `QMetaType::*`
- **qdltmsg.cpp** — Replace deprecated `QDateTime(date, time, Qt::UTC)` with `QTimeZone::utc()`; add `#include <QTimeZone>`; suppress unused variable with `Q_UNUSED`
- **qdltexporter.cpp** — Initialize `QFile* file = nullptr` to avoid uninitialized pointer warning
- **qdltoptmanager.cpp** — Fix dangling reference by changing `const QString&` to `QString` (by value)
- **fieldnames.cpp** — Add `[[fallthrough]]` to intentional switch fallthroughs
- **dlt_common.c** — Fix unaligned pointer access on packed struct member by copying value before taking address
- **qdltfile.cpp** — Remove always-false comparison (`uint16_t > 65535`)
- **plugintreewidget.cpp** — Replace deprecated `event->pos()` with `event->position().toPoint()`
- **sortfilterproxymodel.cpp** — Replace deprecated `invalidateFilter()` with `beginFilterChange()`/`endFilterChange()`
- **mainwindow.cpp** — Fix member initializer list order to match declaration order; handle `QFile::open()` return value
- **commander/main.cpp** — Handle `QFile::open()` return value
- **dlt_viewer.rc** — Fix backslash in icon path causing unrecognized escape sequence warning

## Test Environment
- Windows 11
- Qt 6.11.0 (MinGW 13.1.0 64-bit)
- CMake 3.30.5 + Ninja