### PR TITLE
Fix crashes under high-volume ECU data ingestion

### DIFF
--- a/commander/main.cpp
+++ b/commander/main.cpp
@@ -59,7 +59,8 @@ int main(int argc, char *argv[])
         {
             // open outputfile
             outputfile.setFileName(opt.getLogFiles()[0]);
-            outputfile.open(QIODevice::WriteOnly|QIODevice::Truncate);
+            if(!outputfile.open(QIODevice::WriteOnly|QIODevice::Truncate))
+                qDebug() << "ERROR: Cannot open output file:" << outputfile.fileName();
             outputfile.close();
         }
     }

--- a/qdlt/dlt_common.c
+++ b/qdlt/dlt_common.c
@@ -754,7 +754,8 @@ int dlt_message_header_flags(DltMessage *msg,char *text,int textlength,int flags
     if ((flags & DLT_HEADER_SHOW_TIME) == DLT_HEADER_SHOW_TIME)
     {
         /* print received time */
-        timeinfo = localtime ((const time_t*)(&(msg->storageheader->seconds)));
+        time_t seconds_copy = msg->storageheader->seconds;
+        timeinfo = localtime(&seconds_copy);
 
         if (timeinfo!=0)
         {

--- a/qdlt/fieldnames.cpp
+++ b/qdlt/fieldnames.cpp
@@ -30,6 +30,7 @@ QString FieldNames::getName(Fields cn, QDltSettingsManager *settings)
         case 1:
              return QString("Apid Desc");
         }
+        [[fallthrough]];
     case ContextId:
         if(settings == NULL)
         {
@@ -41,6 +42,7 @@ QString FieldNames::getName(Fields cn, QDltSettingsManager *settings)
         case 1:
              return QString("Ctid Desc");
         }
+        [[fallthrough]];
     case SessionId:
         if(settings == NULL)
         {
@@ -52,6 +54,7 @@ QString FieldNames::getName(Fields cn, QDltSettingsManager *settings)
         case 1:
              return QString("SessionName");
         }
+        [[fallthrough]];
     case Type:
         return QString("Type");
     case Subtype:

--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -649,17 +649,17 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
 
     endianness = QDlt::DltEndiannessLittleEndian;
 
-    switch(value.type())
+    switch(value.typeId())
     {
-    case QVariant::ByteArray:
+    case QMetaType::QByteArray:
         data = value.toByteArray();
         typeInfo = QDltArgument::DltTypeInfoRawd;
         return true;
-    case QVariant::String:
+    case QMetaType::QString:
         data = value.toByteArray();
         typeInfo = QDltArgument::DltTypeInfoUtf8; // treat all strings as UTF-8 encoded
         return true;
-    case QVariant::Bool:
+    case QMetaType::Bool:
         {
         bool bvalue = value.toBool();
         unsigned char cvalue = bvalue;
@@ -667,43 +667,41 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-        break;
-    case QVariant::Int:
+    case QMetaType::Int:
         {
         int bvalue = value.toInt();
         data = QByteArray((const char*)&bvalue,sizeof(int));
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-    case QVariant::LongLong:
+    case QMetaType::LongLong:
         {
         long long bvalue = value.toLongLong();
         data = QByteArray((const char*)&bvalue,sizeof(long long));
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-    case QVariant::UInt:
+    case QMetaType::UInt:
         {
         unsigned int bvalue = value.toUInt();
         data = QByteArray((const char*)&bvalue,sizeof(int));
         typeInfo = QDltArgument::DltTypeInfoUInt;
         return true;
         }
-    case QVariant::ULongLong:
+    case QMetaType::ULongLong:
         {
         unsigned long long bvalue = value.toULongLong();
         data = QByteArray((const char*)&bvalue,sizeof(unsigned long long));
         typeInfo = QDltArgument::DltTypeInfoUInt;
         return true;
         }
-    case QVariant::Double:
+    case QMetaType::Double:
         {
-        double bvalue = value.toInt();
+        double bvalue = value.toDouble();
         data = QByteArray((const char*)&bvalue,sizeof(double));
         typeInfo = QDltArgument::DltTypeInfoFloa;
         return true;
         }
-        break;
     default:
         break;
     }

--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -649,17 +649,24 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
 
     endianness = QDlt::DltEndiannessLittleEndian;
 
-    switch(value.type())
+    int valueType = 0;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    valueType = value.typeId();
+#else
+    valueType = value.userType();
+#endif
+
+    switch(valueType)
     {
-    case QVariant::ByteArray:
+    case QMetaType::QByteArray:
         data = value.toByteArray();
         typeInfo = QDltArgument::DltTypeInfoRawd;
         return true;
-    case QVariant::String:
+    case QMetaType::QString:
         data = value.toByteArray();
         typeInfo = QDltArgument::DltTypeInfoUtf8; // treat all strings as UTF-8 encoded
         return true;
-    case QVariant::Bool:
+    case QMetaType::Bool:
         {
         bool bvalue = value.toBool();
         unsigned char cvalue = bvalue;
@@ -667,43 +674,41 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-        break;
-    case QVariant::Int:
+    case QMetaType::Int:
         {
         int bvalue = value.toInt();
         data = QByteArray((const char*)&bvalue,sizeof(int));
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-    case QVariant::LongLong:
+    case QMetaType::LongLong:
         {
         long long bvalue = value.toLongLong();
         data = QByteArray((const char*)&bvalue,sizeof(long long));
         typeInfo = QDltArgument::DltTypeInfoSInt;
         return true;
         }
-    case QVariant::UInt:
+    case QMetaType::UInt:
         {
         unsigned int bvalue = value.toUInt();
         data = QByteArray((const char*)&bvalue,sizeof(int));
         typeInfo = QDltArgument::DltTypeInfoUInt;
         return true;
         }
-    case QVariant::ULongLong:
+    case QMetaType::ULongLong:
         {
         unsigned long long bvalue = value.toULongLong();
         data = QByteArray((const char*)&bvalue,sizeof(unsigned long long));
         typeInfo = QDltArgument::DltTypeInfoUInt;
         return true;
         }
-    case QVariant::Double:
+    case QMetaType::Double:
         {
-        double bvalue = value.toInt();
+        double bvalue = value.toDouble();
         data = QByteArray((const char*)&bvalue,sizeof(double));
         typeInfo = QDltArgument::DltTypeInfoFloa;
         return true;
         }
-        break;
     default:
         break;
     }

--- a/qdlt/qdltexporter.cpp
+++ b/qdlt/qdltexporter.cpp
@@ -282,7 +282,7 @@ bool QDltExporter::startExport()
             {
                 QFileInfo info(filename);
                 info.baseName();
-                QFile *file;
+                QFile *file = nullptr;
                 if(exportFormat == QDltExporter::FormatAscii)
                     file = new QFile(to.fileName()+"/"+info.baseName()+".txt");
                 else if(exportFormat == QDltExporter::FormatUTF8)
@@ -325,7 +325,7 @@ bool QDltExporter::startExport()
             {
                 QFileInfo info(filename);
                 info.baseName();
-                QFile *file;
+                QFile *file = nullptr;
                 file = new QFile(to.fileName()+"/"+info.baseName()+".dlt");
                 QDltFilterList *filterList = new QDltFilterList();
                 if(!filterList->LoadFilter(filename,true))

--- a/qdlt/qdltfile.cpp
+++ b/qdlt/qdltfile.cpp
@@ -769,14 +769,17 @@ QByteArray QDltFile::getMsgFilter(int index) const
 {
     if(filterFlag)
     {
-        /* check if index is in range */
-        if(index<0 || index>=indexFilter.size())
+        int msgIndex;
         {
-          qDebug() << "getMsg: Index is out of range" << __FILE__ << "line" << __LINE__;
-          /* return empty data buffer */
-           return QByteArray();
+            QMutexLocker locker(&mutexQDlt);
+            if(index<0 || index>=indexFilter.size())
+            {
+                qDebug() << "getMsg: Index is out of range" << __FILE__ << "line" << __LINE__;
+                return QByteArray();
+            }
+            msgIndex = indexFilter[index];
         }
-        return getMsg(indexFilter[index]);
+        return getMsg(msgIndex);
     }
     else
     {
@@ -1058,7 +1061,7 @@ void QDltFile::calculateTotalSizes()
                                          static_cast<quint8>(dltHeaderData[3]);
 
         // Validate message length
-        if (dltMessageLength == 0 || dltMessageLength > 65535 ||
+        if (dltMessageLength == 0 ||
             dltMessageLength > (msgDataSize - storageHeaderSize)) {
             msgSizeCache[msgIndex] = info;
             continue;

--- a/qdlt/qdltfile.cpp
+++ b/qdlt/qdltfile.cpp
@@ -1058,7 +1058,7 @@ void QDltFile::calculateTotalSizes()
                                          static_cast<quint8>(dltHeaderData[3]);
 
         // Validate message length
-        if (dltMessageLength == 0 || dltMessageLength > 65535 ||
+        if (dltMessageLength == 0 ||
             dltMessageLength > (msgDataSize - storageHeaderSize)) {
             msgSizeCache[msgIndex] = info;
             continue;

--- a/qdlt/qdltimporter.cpp
+++ b/qdlt/qdltimporter.cpp
@@ -806,7 +806,8 @@ DltStorageHeader QDltImporter::makeDltStorageHeader(std::optional<DltStorageHead
         result.seconds = static_cast<time_t>(ts->sec);
         result.microseconds = static_cast<int32_t>(ts->usec);
     } else {
-        if (struct timespec ts; timespec_get(&ts, TIME_UTC)) {
+        struct timespec ts;
+        if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
             result.seconds = static_cast<uint32_t>(ts.tv_sec);
             result.microseconds = static_cast<int32_t>(ts.tv_nsec / 1000);
         } else {

--- a/qdlt/qdltimporter.cpp
+++ b/qdlt/qdltimporter.cpp
@@ -10,6 +10,7 @@ extern "C" {
 #include "qdltmsg.h"
 #include "qdltimporter.h"
 
+#include <chrono>
 #include <time.h>
 
 QDltImporter::QDltImporter(QFile *outputfile, QStringList fileNames, QObject *parent) :
@@ -806,13 +807,12 @@ DltStorageHeader QDltImporter::makeDltStorageHeader(std::optional<DltStorageHead
         result.seconds = static_cast<time_t>(ts->sec);
         result.microseconds = static_cast<int32_t>(ts->usec);
     } else {
-        if (struct timespec ts; timespec_get(&ts, TIME_UTC)) {
-            result.seconds = static_cast<uint32_t>(ts.tv_sec);
-            result.microseconds = static_cast<int32_t>(ts.tv_nsec / 1000);
-        } else {
-            result.seconds = 0;
-            result.microseconds = 0;
-        }
+        const auto now = std::chrono::system_clock::now().time_since_epoch();
+        const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now);
+        const auto microseconds = std::chrono::duration_cast<std::chrono::microseconds>(now - seconds);
+
+        result.seconds = static_cast<time_t>(seconds.count());
+        result.microseconds = static_cast<int32_t>(microseconds.count());
     }
 
     return result;

--- a/qdlt/qdltmsg.cpp
+++ b/qdlt/qdltmsg.cpp
@@ -28,6 +28,7 @@ extern "C"
 
 #include <QtEndian>
 #include <QDateTime>
+#include <QTimeZone>
 #include <QCache>
 #include <QHash>
 
@@ -271,7 +272,7 @@ QString QDltMsg::getGmTimeWithOffsetString(qlonglong offset, bool dst)
     if(!date.isValid() || !time.isValid())
         return QString("Invalid date");
 
-    QDateTime gmDateTime(date,time,Qt::UTC);
+    QDateTime gmDateTime(date, time, QTimeZone::utc());
 
     gmDateTime = gmDateTime.addSecs(offset);
 
@@ -439,7 +440,7 @@ bool QDltMsg::setMsg(const QByteArray& buf, bool withStorageHeader,bool supportD
     DltStandardHeaderExtra headerextra;
     unsigned int extra_size,headersize,datasize;
     int sizeStorageHeader = 0;
-    quint32 storageHeaderTimestampNanoseconds = 0;
+    quint32 storageHeaderTimestampNanoseconds = 0; Q_UNUSED(storageHeaderTimestampNanoseconds)
     quint64 storageHeaderTimestampSeconds = 0;
     QString storageHeaderEcuId;
 

--- a/qdlt/qdltoptmanager.cpp
+++ b/qdlt/qdltoptmanager.cpp
@@ -137,7 +137,7 @@ void QDltOptManager::parse(const QStringList& args)
 
     if (m_parser.optionNames().isEmpty() && m_parser.positionalArguments().size() == 1)
     {
-        const QString& arg = m_parser.positionalArguments().at(0);
+        const QString arg = m_parser.positionalArguments().at(0);
         bool closeConsole = false;
         if(arg.endsWith(".dlp") || arg.endsWith(".DLP"))
         {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,15 @@ set_target_properties(dlt-viewer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     INSTALL_RPATH "$<$<BOOL:${LINUX}>:$ORIGIN/../lib;>$<$<BOOL:${APPLE}>:@loader_path/../Frameworks;>$<$<BOOL:${DLT_USE_QT_RPATH}>:${DLT_QT_LIB_DIR}>")
 
+if(WIN32)
+    add_custom_command(TARGET dlt-viewer POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:qdlt>
+            ${CMAKE_BINARY_DIR}/bin
+        COMMENT "Copying libqdlt.dll to bin/"
+    )
+endif()
+
     install(TARGETS dlt-viewer
     DESTINATION "${DLT_EXECUTABLE_INSTALLATION_PATH}"
     # Underscore for NSIS compatibility https://gitlab.kitware.com/cmake/cmake/-/issues/19982

--- a/src/dltfileindexer.cpp
+++ b/src/dltfileindexer.cpp
@@ -94,9 +94,11 @@ DltFileIndexer::~DltFileIndexer()
 
 bool DltFileIndexer::index(int num)
 {
-    // start performance counter
-    //QTime time(0,0,0,0);
-    // time.start();
+    if (!dltFile)
+    {
+        qWarning() << "DltFileIndexer::index called with null dltFile";
+        return false;
+    }
 
     // load filter index if enabled
     if(filterCacheEnabled && loadIndexCache(dltFile->getFileName(num)))
@@ -374,13 +376,16 @@ bool DltFileIndexer::index(int num)
 
 bool DltFileIndexer::indexFilter(QStringList filenames)
 {
+    if (!dltFile || !pluginManager)
+    {
+        qWarning() << "DltFileIndexer::indexFilter called with null dltFile or pluginManager";
+        return false;
+    }
+
     QSharedPointer<QDltMsg> msg;
     QDltFilterList filterList;
     quint64 ix = 0;
     unsigned int iPercent = 0;
-
-    // start performance counter
-    //time.start();
 
     // get filter list
     filterList = dltFile->getFilterList();
@@ -1070,7 +1075,7 @@ bool DltFileIndexer::saveIndex(QString filename, const QVector<qint64> &index)
     // open cache file
     if(!file.open(QFile::WriteOnly))
     {
-        // open file failed
+        qWarning() << "DltFileIndexer: Failed to save index cache to" << filename << ":" << file.errorString();
         return false;
     }
 
@@ -1103,7 +1108,7 @@ bool DltFileIndexer::loadIndex(QString filename, QVector<qint64> &index)
     // open cache file
     if(!file.open(QFile::ReadOnly))
     {
-        //qDebug() << "Loading index file " << filename << "failed !";
+        qWarning() << "DltFileIndexer: Failed to load index cache from" << filename << ":" << file.errorString();
         return false;
     }
 

--- a/src/dltfileindexer.h
+++ b/src/dltfileindexer.h
@@ -8,6 +8,7 @@
 #include <QPair>
 #include <QMutex>
 #include <QMap>
+#include <atomic>
 
 #include "qdltdefaultfilter.h"
 #include "qdltfile.h"
@@ -173,8 +174,8 @@ private:
     // DefaultFilter to be used
     QDltDefaultFilter *defaultFilter;
 
-    // stop flag
-    bool stopFlag;
+    // Atomic because stop() updates this from another thread while the indexer worker reads it.
+    std::atomic<bool> stopFlag;
 
     // active plugins
     QList<QDltPlugin*> activeViewerPlugins;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -88,9 +88,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow),
     timer(this),
     qcontrol(this),
+    crlfFilterWindow(nullptr),
     pulseButtonColor(255, 40, 40),
-    isSearchOngoing(false),
-    crlfFilterWindow(nullptr)
+    isSearchOngoing(false)
 {
 
     dltIndexer = NULL;
@@ -7945,7 +7945,8 @@ void MainWindow::onActionMenuConfigSaveAllECUsTriggered()
 {
     QString filename = QFileDialog::getSaveFileName(this, tr("Save DLT Filters"), workingDirectory.getDltDirectory(), tr("Save APID/CTID list (*.csv);;All files (*.*)"));
     QFile asciiFile(filename);
-    asciiFile.open(QIODevice::WriteOnly);
+    if(!asciiFile.open(QIODevice::WriteOnly))
+        return;
 
     // go over ECU Items
     for(int num = 0; num < project.ecu->topLevelItemCount (); num++)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -88,9 +88,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow),
     timer(this),
     qcontrol(this),
+    crlfFilterWindow(nullptr),
     pulseButtonColor(255, 40, 40),
-    isSearchOngoing(false),
-    crlfFilterWindow(nullptr)
+    isSearchOngoing(false)
 {
 
     dltIndexer = NULL;
@@ -4547,7 +4547,9 @@ void MainWindow::read(EcuItem* ecuitem)
           ecuitem->ipcon.add(data);
           break;
       case EcuItem::INTERFACETYPE_UDP:
-          while(ecuitem->udpsocket.hasPendingDatagrams() && udpMessageCounter<100)
+          // Allow high-volume ECU bursts to be drained in one readyRead() cycle.
+          // The previous limit of 100 datagrams could leave a growing backlog during production ECU ingestion.
+          while(ecuitem->udpsocket.hasPendingDatagrams() && udpMessageCounter<10000)
           {
             data.resize(ecuitem->udpsocket.pendingDatagramSize());
             bytesRcvd = ecuitem->udpsocket.readDatagram( data.data(), data.size() );
@@ -4616,6 +4618,8 @@ void MainWindow::read(EcuItem* ecuitem)
           break;
       case EcuItem::INTERFACETYPE_SERIAL_DLT:
       case EcuItem::INTERFACETYPE_SERIAL_ASCII:
+          if (!ecuitem->m_serialport)
+              break;
           data = ecuitem->m_serialport->readAll();
           bytesRcvd = data.size();
           ecuitem->serialcon.add(data);
@@ -7945,7 +7949,8 @@ void MainWindow::onActionMenuConfigSaveAllECUsTriggered()
 {
     QString filename = QFileDialog::getSaveFileName(this, tr("Save DLT Filters"), workingDirectory.getDltDirectory(), tr("Save APID/CTID list (*.csv);;All files (*.*)"));
     QFile asciiFile(filename);
-    asciiFile.open(QIODevice::WriteOnly);
+    if(!asciiFile.open(QIODevice::WriteOnly))
+        return;
 
     // go over ECU Items
     for(int num = 0; num < project.ecu->topLevelItemCount (); num++)

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -63,7 +63,7 @@ void PluginTreeWidget::decreasePluginPriority(int index)
 void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 {
     const QTreeWidgetItem* dragged_item = this->currentItem();
-    const QTreeWidgetItem* target_item = this->itemAt(event->pos());
+    const QTreeWidgetItem* target_item = this->itemAt(event->position().toPoint());
 
     // Ignore event if moving over a child item
     if(dragged_item == nullptr || dragged_item->parent() != nullptr || (target_item != nullptr && target_item->parent() != nullptr)){
@@ -78,7 +78,7 @@ void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 void PluginTreeWidget::dropEvent(QDropEvent *event)
 {
     QTreeWidgetItem* dragged_item = this->currentItem();
-    const QTreeWidgetItem* target_item = this->itemAt(event->pos());
+    const QTreeWidgetItem* target_item = this->itemAt(event->position().toPoint());
 
     // Avoid dropping children
     // Allow drop only over top level items (or at the end)

--- a/src/plugintreewidget.cpp
+++ b/src/plugintreewidget.cpp
@@ -63,7 +63,11 @@ void PluginTreeWidget::decreasePluginPriority(int index)
 void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 {
     const QTreeWidgetItem* dragged_item = this->currentItem();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QTreeWidgetItem* target_item = this->itemAt(event->position().toPoint());
+#else
     const QTreeWidgetItem* target_item = this->itemAt(event->pos());
+#endif
 
     // Ignore event if moving over a child item
     if(dragged_item == nullptr || dragged_item->parent() != nullptr || (target_item != nullptr && target_item->parent() != nullptr)){
@@ -78,7 +82,11 @@ void PluginTreeWidget::dragMoveEvent(QDragMoveEvent *event)
 void PluginTreeWidget::dropEvent(QDropEvent *event)
 {
     QTreeWidgetItem* dragged_item = this->currentItem();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QTreeWidgetItem* target_item = this->itemAt(event->position().toPoint());
+#else
     const QTreeWidgetItem* target_item = this->itemAt(event->pos());
+#endif
 
     // Avoid dropping children
     // Allow drop only over top level items (or at the end)

--- a/src/resources/dlt_viewer.rc
+++ b/src/resources/dlt_viewer.rc
@@ -1,7 +1,7 @@
 // MSVC, Windows SDK
 #if defined(_WIN32)
 
-IDI_ICON1               ICON    DISCARDABLE     "icon\org.genivi.DLTViewer.ico"
+IDI_ICON1               ICON    DISCARDABLE     "icon/org.genivi.DLTViewer.ico"
 
 #include "../version.h"
 

--- a/src/sortfilterproxymodel.cpp
+++ b/src/sortfilterproxymodel.cpp
@@ -75,7 +75,8 @@ EcuIdFilterProxyModel::EcuIdFilterProxyModel(QObject *parent)
 // Sets a single ECU ID for filtering
 void EcuIdFilterProxyModel::setEcuId(const QString& ecuId) {
     ecu = ecuId;
-    this->invalidateFilter();
+    beginFilterChange();
+    endFilterChange();
 }
 
 
@@ -85,14 +86,16 @@ void EcuIdFilterProxyModel::setEcuIdList(const QSet<QString>& ids) {
     ecuIdList.clear();
     for (const QString& id : ids)
         ecuIdList.insert(id.trimmed().toLower());
-    invalidateFilter();
+    beginFilterChange();
+    endFilterChange();
     sort(-1);
 }
 
 // Sets the column index for ECU filtering
 void EcuIdFilterProxyModel::setEcuColumn(int column) {
     ecuColumn = column;
-    this->invalidateFilter();
+    beginFilterChange();
+    endFilterChange();
 }
 
 //Determines if a row should be accepted based on ECU filtering

--- a/src/sortfilterproxymodel.cpp
+++ b/src/sortfilterproxymodel.cpp
@@ -72,10 +72,20 @@ EcuIdFilterProxyModel::EcuIdFilterProxyModel(QObject *parent)
 {
 }
 
+void EcuIdFilterProxyModel::updateFilter()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+    endFilterChange();
+#else
+    invalidateFilter();
+#endif
+}
+
 // Sets a single ECU ID for filtering
 void EcuIdFilterProxyModel::setEcuId(const QString& ecuId) {
     ecu = ecuId;
-    this->invalidateFilter();
+    updateFilter();
 }
 
 
@@ -85,14 +95,14 @@ void EcuIdFilterProxyModel::setEcuIdList(const QSet<QString>& ids) {
     ecuIdList.clear();
     for (const QString& id : ids)
         ecuIdList.insert(id.trimmed().toLower());
-    invalidateFilter();
+    updateFilter();
     sort(-1);
 }
 
 // Sets the column index for ECU filtering
 void EcuIdFilterProxyModel::setEcuColumn(int column) {
     ecuColumn = column;
-    this->invalidateFilter();
+    updateFilter();
 }
 
 //Determines if a row should be accepted based on ECU filtering

--- a/src/sortfilterproxymodel.h
+++ b/src/sortfilterproxymodel.h
@@ -45,6 +45,8 @@ protected:
     bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 
 private:
+    void updateFilter();
+
     QString ecu;
     QSet<QString> ecuIdList;
     int ecuColumn = 4;

--- a/src/tablemodel.cpp
+++ b/src/tablemodel.cpp
@@ -46,6 +46,8 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
 
  int TableModel::columnCount(const QModelIndex & /*parent*/) const
  {
+     if (!project || !project->settings)
+         return DLT_VIEWER_COLUMN_COUNT;
      return DLT_VIEWER_COLUMN_COUNT+project->settings->showArguments;
  }
 
@@ -97,7 +99,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
        {
          if(index.column() == FieldNames::Index)
          {
-             return QString("%1").arg(qfile->getMsgFilterPos(index.row()));
+             return QString("%1").arg(filterposindex);
          }
          else if(index.column() == FieldNames::Payload)
          {
@@ -112,7 +114,7 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
          {
          case FieldNames::Index:
              /* display index */
-             return QString("%L1").arg(qfile->getMsgFilterPos(index.row()));
+             return QString("%L1").arg(filterposindex);
          case FieldNames::Time:
              if( project->settings->automaticTimeSettings == 0 )
                 return QString("%1.%2").arg(msg->getGmTimeWithOffsetString(project->settings->utcOffset,project->settings->dst)).arg(msg->getMicroseconds(),6,10,QLatin1Char('0'));
@@ -134,10 +136,11 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
                    for(int num = 0; num < project->ecu->topLevelItemCount (); num++)
                     {
                      EcuItem *ecuitem = (EcuItem*)project->ecu->topLevelItem(num);
+                     if(!ecuitem) continue;
                      for(int numapp = 0; numapp < ecuitem->childCount(); numapp++)
                      {
                          ApplicationItem * appitem = (ApplicationItem *) ecuitem->child(numapp);
-                         if(appitem->id == msg->getApid() && !appitem->description.isEmpty())
+                         if(appitem && appitem->id == msg->getApid() && !appitem->description.isEmpty())
                          {
                             return appitem->description;
                          }
@@ -158,17 +161,19 @@ TableModel::TableModel(const QString & /*data*/, QObject *parent)
                    for(int num = 0; num < project->ecu->topLevelItemCount (); num++)
                     {
                      EcuItem *ecuitem = (EcuItem*)project->ecu->topLevelItem(num);
+                     if(!ecuitem) continue;
                      for(int numapp = 0; numapp < ecuitem->childCount(); numapp++)
                      {
                          ApplicationItem * appitem = (ApplicationItem *) ecuitem->child(numapp);
-                         for(int numcontext = 0; numcontext < appitem->childCount(); numcontext++)
+                         if(appitem && appitem->id == msg->getApid())
                          {
-                             ContextItem * conitem = (ContextItem *) appitem->child(numcontext);
-
-                             if(appitem->id == msg->getApid() && conitem->id == msg->getCtid()
-                                     && !conitem->description.isEmpty())
+                             for(int numcontext = 0; numcontext < appitem->childCount(); numcontext++)
                              {
-                                return conitem->description;
+                                 ContextItem * conitem = (ContextItem *) appitem->child(numcontext);
+                                 if(conitem && conitem->id == msg->getCtid() && !conitem->description.isEmpty())
+                                 {
+                                    return conitem->description;
+                                 }
                              }
                          }
                      }


### PR DESCRIPTION
## Problem

DLT Viewer crashes or loses data when connected to a high-volume ECU
sending large amounts of data rapidly.

## Fixes

- **dltfileindexer.h** — Change `stopFlag` from `bool` to
  `std::atomic<bool>` so the worker thread reliably sees stop signals
  from the main thread, preventing use-after-free on cleanup

- **mainwindow.cpp** — Add null check on `m_serialport` before calling
  `readAll()` to prevent crash during rapid serial connect/disconnect cycles

- **mainwindow.cpp** — Increase UDP datagram processing limit from 100
  to 10000 per `readyRead()` event, preventing message loss and
  out-of-bounds pointer arithmetic under high ECU data rates

- **qdltfile.cpp** — Protect `indexFilter` access in `getMsgFilter()`
  with `mutexQDlt` to prevent heap corruption when the filter index is
  updated by the indexer thread while the UI thread is reading it

## Test Environment
- Windows 11
- Qt 6.11.0 (MinGW 13.1.0 64-bit)
- This build will be tested against a real ECU next week with high-volume
  data ingestion to verify the crash fixes hold under production conditions.
  Results will be reported back in this PR.