### PR TITLE
qdlt: fix correctness and safety bugs in argument and segmented-msg p…

### DIFF
--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -698,7 +698,7 @@ bool QDltArgument::setValue(QVariant value, bool verboseMode)
         }
     case QVariant::Double:
         {
-        double bvalue = value.toInt();
+        double bvalue = value.toDouble();
         data = QByteArray((const char*)&bvalue,sizeof(double));
         typeInfo = QDltArgument::DltTypeInfoFloa;
         return true;

--- a/qdlt/qdltsegmentedmsg.cpp
+++ b/qdlt/qdltsegmentedmsg.cpp
@@ -151,7 +151,19 @@ int QDltSegmentedMsg::add(QDltMsg &msg)
             error = "Invalid Type in chunk segment message";
             return -1;
         }
-        payload.replace(sequence*chunkSize,chunkSize,argument.getData());
+
+        // Compute the chunk's absolute offset in 64-bit so that
+        // sequence * chunkSize cannot wrap as uint32_t for crafted
+        // start-segment messages, then reject any chunk whose end
+        // would extend past the (already-resized) payload buffer.
+        const quint64 chunk_offset = static_cast<quint64>(sequence) * static_cast<quint64>(chunkSize);
+        if (chunk_offset + chunkSize > static_cast<quint64>(payload.size()))
+        {
+            error = QString("Chunk extends past payload: sequence=%1 offset=%2 chunkSize=%3 payloadSize=%4")
+                        .arg(sequence).arg(chunk_offset).arg(chunkSize).arg(payload.size());
+            return -1;
+        }
+        payload.replace(static_cast<int>(chunk_offset),chunkSize,argument.getData());
 
         chunksAdded += 1;
     }


### PR DESCRIPTION
## Problem

Two unrelated but small bugs in `qdlt/`, both real and reachable:

### 1. `QDltArgument::setValue` — `toInt()` instead of `toDouble()`

`qdlt/qdltargument.cpp:699–705`:

```cpp
case QVariant::Double:
    {
    double bvalue = value.toInt();          // ← bug
    data = QByteArray((const char*)&bvalue, sizeof(double));
    typeInfo = QDltArgument::DltTypeInfoFloa;
    return true;
    }
```

When a `QVariant::Double` is passed to `setValue()`, the code reads
its integer value and stores that as a `double`. Effects:

- `setValue(QVariant(3.14))` → stores `3.0` (fractional part lost).
- `setValue(QVariant(NaN))`  → stores `0.0` (`toInt()` returns 0).
- `setValue(QVariant(1.5e15))` → silently clamped to int range.

Anywhere DLT messages are constructed programmatically with floating-
point arguments via this overload, the wire output is wrong.

Fix: `value.toInt()` → `value.toDouble()`. One-character change.

### 2. `QDltSegmentedMsg::add` — `sequence * chunkSize` overflow

`qdlt/qdltsegmentedmsg.cpp:141–154`:

```cpp
uint32_t sequence = argument.getValue().toUInt();
if(sequence>=chunks) {
    error = ...;
    return -1;
}
...
payload.replace(sequence*chunkSize, chunkSize, argument.getData());
```

Both `sequence` (chunk segment) and `chunkSize` (start segment) come
from the wire. The check `sequence < chunks` only validates the
chunk index; the multiplication `sequence * chunkSize` is performed
in `uint32_t` and can wrap. With a crafted start segment declaring a
large `chunkSize` and a chunk-segment message with a small but
non-zero `sequence`, the product wraps to a value smaller than
`payload.size()`, so `payload.replace()` succeeds but writes the
chunk into the wrong region of the buffer.

Fix: compute the offset in `quint64` so the multiplication can't
wrap, then reject any chunk whose end (`chunk_offset + chunkSize`)
would extend past the resized payload size before calling
`replace()`.

## Verification

- Read both functions in full; existing checks before each fix do
  not cover the cases above.
- `payload` is `resize`d to the start-segment-declared size at
  line 112, which the new bound-check uses as the upper limit.
- Cast back to `int` for the `replace()` call is safe after the
  bound check has guaranteed the offset fits.

## Notes

- No new tests added; happy to add `qdlt/tests/`-style coverage if
  maintainers point me at the right harness shape.
- Defensive bounds-checks on `mid()` calls in `qdltargument.cpp:174,178`
  and `qdltimporter.cpp:942` are real but milder (Qt's `mid()`
  truncates gracefully rather than reading OOB), and I'll send
  those as a separate PR rather than bundle here.