### PR TITLE
qdlt: defensive bounds checks before mid() on attacker-supplied lengths

### DIFF
--- a/qdlt/qdltargument.cpp
+++ b/qdlt/qdltargument.cpp
@@ -171,10 +171,18 @@ bool QDltArgument::setArgument(QByteArray &payload,unsigned int &offset, QDlt::D
                 length3 = DLT_SWAP_16((*((unsigned short*) (payload.constData()+offset))));
             offset += sizeof(unsigned short);
         }
+        // length2/length3 come from the wire and are uncapped uint16_t.
+        // Without these checks Qt's QByteArray::mid() silently truncates
+        // when (offset + lengthN) exceeds payload.size(), producing a
+        // shorter-than-claimed name/unit string instead of failing.
+        if((unsigned int)payload.size()<(offset+length2))
+            return false;
         name = QString(payload.mid(offset,length2));
         offset += length2;
         if(typeInfo == DltTypeInfoSInt || typeInfo == DltTypeInfoUInt || typeInfo == DltTypeInfoFloa)
         {
+            if((unsigned int)payload.size()<(offset+length3))
+                return false;
             unit = QString(payload.mid(offset,length3));
             offset += length3;
         }

--- a/qdlt/qdltimporter.cpp
+++ b/qdlt/qdltimporter.cpp
@@ -939,7 +939,23 @@ bool QDltImporter::ipcFromEthernetFrame(QByteArray &record,int pos,quint16 ether
                    }
                    else
                    {
-                       arg3.setData(record.mid(pos+35,qFromBigEndian(plpHeaderData->length)-35));
+                       // plpHeaderData->length comes from the wire as a
+                       // uint16_t. If it's smaller than the 35-byte IPC
+                       // header, the subtraction below underflows and
+                       // QByteArray::mid() interprets the resulting
+                       // negative qsizetype as "to end of buffer", so
+                       // arg3 silently swallows the entire trailing
+                       // record instead of the intended slice. Skip the
+                       // malformed packet rather than emit garbage.
+                       const auto plp_length = qFromBigEndian(plpHeaderData->length);
+                       if (plp_length < 35)
+                       {
+                           qDebug() << "ipcFromEthernetFrame: plp length"
+                                    << plp_length
+                                    << "below IPC header size, skipping";
+                           break;
+                       }
+                       arg3.setData(record.mid(pos+35, plp_length-35));
                    }
                    msg.addArgument(arg3);
 


### PR DESCRIPTION
## Problem

Two related fixes in the verbose-mode argument parser and the IPC
ethernet-frame importer. In both cases a length field read from the
wire is passed to `QByteArray::mid()` without first verifying the
source buffer can satisfy it.

Qt's `mid()` handles out-of-range arguments gracefully — it truncates
to buffer end if `offset + size > buffer.size()`, and treats a
*negative* `size` as "from offset to end of buffer." So neither
call reads OOB. But both silently produce **wrong-shaped output**
instead of failing on malformed input — which is bad in different
ways depending on what consumes the resulting string/data.

### 1. `QDltArgument::setArgument` — missing length checks before `mid()`

`qdlt/qdltargument.cpp:174,178`:

```cpp
length2 = ... ; // read uint16_t from payload
offset += sizeof(unsigned short);
if (typeInfo == ...) {
    length3 = ... ;
    offset += sizeof(unsigned short);
}
name = QString(payload.mid(offset, length2));   // ← unchecked
offset += length2;
if (typeInfo == ...) {
    unit = QString(payload.mid(offset, length3));  // ← unchecked
    offset += length3;
}
```

`length2` / `length3` are uncapped `uint16_t` values. The function
already does the same shape of check before reading the fixed
length fields above (`if(payload.size() < offset + sizeof(short))
return false;`), and again later for the type-data field
(line 193). The variable name/unit fields just got skipped.

### 2. `QDltImporter::ipcFromEthernetFrame` — `length - 35` underflow

`qdlt/qdltimporter.cpp:942`:

```cpp
arg3.setData(record.mid(pos+35,
                        qFromBigEndian(plpHeaderData->length) - 35));
```

`plpHeaderData->length` is `uint16_t`. If it's less than 35 (the
IPC header size), the subtraction underflows. The result is
interpreted as a negative `qsizetype` by `mid()`, which Qt treats
as "to end of buffer." `arg3` then contains the entire trailing
record instead of the intended IPC payload — silently corrupting
the imported DLT message.

## Fix

- Add the missing bounds checks in `setArgument` (matching the
  function's existing pattern for fixed-length fields).
- In `ipcFromEthernetFrame`, validate `length >= 35` before the
  subtraction; on failure, log a `qDebug` and break the parse loop
  to skip the malformed packet.

## Notes

- Companion to #804 (real correctness/safety bugs in the same
  module). I'm sending these defensive cases as a separate PR
  because they're genuinely lower-severity (no OOB read; just
  silent wrong-shaped output) and the conversation is more
  "should we trust callers or validate?" than "this is a bug."
- Happy to drop or fold elements of this PR if you'd rather have
  it shipped a different way.