### PR TITLE
Fix unstable search result handling

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -790,7 +790,7 @@ void MainWindow::initSearchTable()
 
 
     /* set table size and en */
-   for  (int col=0;col <= m_searchresultsTable->model()->columnCount();col++)
+     for  (int col=0;col < m_searchresultsTable->model()->columnCount();col++)
    {
      m_searchresultsTable->setColumnWidth(col,FieldNames::getColumnWidth((FieldNames::Fields)col,settings));
    }
@@ -8490,9 +8490,7 @@ void MainWindow::searchTableRenewed()
         ui->dockWidgetSearchIndex->show();
         ui->dockWidgetSearchIndex->setWindowTitle(hits);
     }
-    m_searchtableModel->modelChanged();
 }
-
 
 void MainWindow::searchtable_cellSelected( QModelIndex index)
 {

--- a/src/searchdialog.cpp
+++ b/src/searchdialog.cpp
@@ -824,11 +824,14 @@ void SearchDialog::findPreviousClicked()
 
 void SearchDialog::on_lineEditSearch_textEdited(QString newText)
 {
+        if (lineEdits.size() > 1)
         {
             // block signal so that it does not trigger a setText back on lineEdits->at(0)!
             QSignalBlocker signalBlocker(lineEdits.at(1));
             lineEdits.at(1)->setText(newText);
         }
+        if (lineEdits.isEmpty())
+            return;
         for(int i=0; i<lineEdits.size();i++){
             if(lineEdits.at(0)->text().isEmpty())
                 setSearchColour(lineEdits.at(i),1);
@@ -836,7 +839,9 @@ void SearchDialog::on_lineEditSearch_textEdited(QString newText)
 }
 void SearchDialog::textEditedFromToolbar(QString newText)
 {
-        {
+        if (lineEdits.isEmpty())
+            return;
+    {
             // block signal so that it does not trigger a setText back on lineEdits->at(1)!
             QSignalBlocker signalBlocker(lineEdits.at(0));
             lineEdits.at(0)->setText(newText);

--- a/src/searchtablemodel.cpp
+++ b/src/searchtablemodel.cpp
@@ -46,7 +46,7 @@ QVariant SearchTableModel::data(const QModelIndex &index, int role) const
     if (!index.isValid())
         return QVariant();
 
-    if (index.row() >= m_searchResultList.size() && index.row()<0)
+    if (index.row() < 0 || index.row() >= m_searchResultList.size())
         return QVariant();
 
     if (role == Qt::DisplayRole)
@@ -323,7 +323,7 @@ void SearchTableModel::add_SearchResultEntries(const QList<unsigned long>& entri
 
 bool SearchTableModel::get_SearchResultEntry(int position, unsigned long &entry)
 {
-    if (position > m_searchResultList.size() || 0 > position )
+    if (position < 0 || position >= m_searchResultList.size())
     {
         return false;
     }


### PR DESCRIPTION
## Summary
- harden search result table bounds checks
- guard search dialog line edit synchronization when toolbar/dialog fields are missing
- fix search result table column sizing and remove a redundant main window refresh

## Validation
- built locally on Windows with Qt 6 and MSVC