### PR TITLE
Preserve all CTIDs in config tree across GetLogInfo messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,164 +1,51 @@
-# SPDX-License-Identifier: MPL-2.0
-#
-# Copyright (C) 2016, Jack S. Smith
-#
-# This file is part of COVESA DLT-Viewer project.
-#
-# This Source Code Form is subject to the terms of the
-# Mozilla Public License (MPL), v. 2.0.
-# If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-# For further information see http://www.covesa.global/.
-#
-# List of changes:
-# 01.Oct.2016, Jack Smith <jack.smith@elektrobit.com>, Original Author
+add_executable(test_qdlt
+    test_dltmessagematcher.cpp
+    test_dltctrlmsg.cpp
+    test_qdltargument.cpp
+    test_qdltmsgwrapper.cpp
+  test_ecutree.cpp
+)
+target_link_libraries(
+  test_qdlt
+  PRIVATE
+    GTest::gtest_main
+    qdlt
+)
 
-cmake_minimum_required (VERSION 3.15)
-# implicitly calls version checks
-include(scripts/windows/version.cmake)
-include(scripts/linux/version.cmake)
+add_test(
+  NAME test_qdlt
+  COMMAND $<TARGET_FILE:test_qdlt>
+)
 
-if(NOT DEFINED DLT_PROJECT_VERSION_MAJOR OR NOT DEFINED DLT_PROJECT_VERSION_MINOR OR NOT DEFINED DLT_PROJECT_VERSION_PATCH)
-    set(DLT_PROJECT_VERSION_MAJOR 0)
-    set(DLT_PROJECT_VERSION_MINOR 0)
-    set(DLT_PROJECT_VERSION_PATCH 0)
-endif()
-message(STATUS "COVESA DLT Viewer version: ${DLT_PROJECT_VERSION_MAJOR}.${DLT_PROJECT_VERSION_MINOR}.${DLT_PROJECT_VERSION_PATCH}")
+# opt manager has its own test executable since its a singleton
+add_executable(test_dltoptmanager
+    test_dltoptmanager.cpp
+)
 
-project(dlt-viewer
-    VERSION ${DLT_PROJECT_VERSION_MAJOR}.${DLT_PROJECT_VERSION_MINOR}.${DLT_PROJECT_VERSION_PATCH}
-    DESCRIPTION "DLT Viewer")
-message(STATUS "DLT Viewer version: ${DLT_PROJECT_VERSION_MAJOR}.${DLT_PROJECT_VERSION_MINOR}.${DLT_PROJECT_VERSION_PATCH}-${DLT_VERSION_SUFFIX}")
+target_link_libraries(
+  test_dltoptmanager
+  PRIVATE
+    GTest::gtest_main
+    qdlt
+)
 
-file(WRITE "${CMAKE_BINARY_DIR}/version.txt" "${DLT_PROJECT_VERSION_MAJOR}.${DLT_PROJECT_VERSION_MINOR}.${DLT_PROJECT_VERSION_PATCH}")
-file(WRITE "${CMAKE_BINARY_DIR}/full_version.txt" "${DLT_PROJECT_VERSION_MAJOR}.${DLT_PROJECT_VERSION_MINOR}.${DLT_PROJECT_VERSION_PATCH}-${DLT_VERSION_SUFFIX}")
+add_test(
+  NAME test_dltoptmanager
+  COMMAND $<TARGET_FILE:test_dltoptmanager>
+)
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-    set(LINUX TRUE)
-endif()
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-set(CMAKE_C_STANDARD 11)
-
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
-endif()
-
-set (CMAKE_AUTOMOC ON)
-set (CMAKE_AUTOUIC ON)
-set (CMAKE_AUTORCC ON)
-
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-get_target_property(DLT_QT_LIBRARY_PATH ${QT_PREFIX}::Core LOCATION)
-get_filename_component(DLT_QT_LIB_DIR ${DLT_QT_LIBRARY_PATH} DIRECTORY)
-
-if(NOT WIN32)
-    option(DLT_USE_QT_RPATH "Use RPATH for QT_LIBRARY_PATH to support non-standard QT install locations" ON)
-    if (DLT_USE_QT_RPATH)
-        # Add Qt to the RPATH, so that there is no need to set LD_LIBRARY_PATH at runtime if Qt is installed in a non-standard location
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${DLT_QT_LIB_DIR}")
-    endif()
-endif()
-
-# Injection of the GCC-specific compilation flags
-if(CMAKE_COMPILER_IS_GNUCXX)
-    message(STATUS "GCC detected, adding compile flags")
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-variadic-macros -Wno-strict-aliasing -fPIC")
-endif()
-
-add_compile_definitions(QT5)
-set(QT5_QT6_COMPAT_VERSION "5.14")
-# add compiler definition to be used for >= Qt 5.14 code
-if(${QT_PREFIX}Core_VERSION VERSION_GREATER_EQUAL ${QT5_QT6_COMPAT_VERSION})
-    add_compile_definitions(QT5_QT6_COMPAT)
-endif()
-
-option(DLT_USE_STANDARD_INSTALLATION_LOCATION "Use standard GNU installation locations" OFF)
-option(DLT_INSTALL_SDK "Install in SDK location" ON)
-if(NOT WIN32)
-    if(NOT DLT_APP_DIR_NAME)
-        set(DLT_APP_DIR_NAME "DLTViewer")
-        if(APPLE)
-            set(DLT_APP_DIR_NAME "DLTViewer.app")
-        endif()
-    endif()
-    if(DLT_USE_STANDARD_INSTALLATION_LOCATION)
-        include(GNUInstallDirs)
-        set(DLT_PLUGIN_INSTALLATION_PATH "${CMAKE_INSTALL_FULL_LIBDIR}/dlt-viewer/plugins")
-        set(DLT_RESOURCE_INSTALLATION_PATH "${CMAKE_INSTALL_FULL_DATADIR}")
-        set(DLT_EXECUTABLE_INSTALLATION_PATH "${CMAKE_INSTALL_FULL_BINDIR}")
-        set(DLT_LIBRARY_INSTALLATION_PATH "${CMAKE_INSTALL_FULL_LIBDIR}")
-    else()
-        if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-            set(CMAKE_INSTALL_PREFIX "DLTViewer")
-        endif()
-        if(NOT DLT_PLUGIN_INSTALLATION_PATH)
-            set(DLT_PLUGIN_INSTALLATION_PATH "${DLT_APP_DIR_NAME}/usr/bin/plugins")
-        endif()
-        if(NOT DLT_RESOURCE_INSTALLATION_PATH)
-            set(DLT_RESOURCE_INSTALLATION_PATH "${DLT_APP_DIR_NAME}/usr/share")
-        endif()
-        if(NOT DLT_EXECUTABLE_INSTALLATION_PATH)
-            set(DLT_EXECUTABLE_INSTALLATION_PATH "${DLT_APP_DIR_NAME}/usr/bin")
-        endif()
-        if(NOT DLT_LIBRARY_INSTALLATION_PATH)
-            set(DLT_LIBRARY_INSTALLATION_PATH "${DLT_APP_DIR_NAME}/usr/lib")
-        endif()
-    endif()
-else()
-    if(NOT DLT_APP_DIR_NAME)
-        set(DLT_APP_DIR_NAME "./")
-    endif()
-    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-        # AppData is a modern install location. No Admin rights required.
-        file(TO_CMAKE_PATH "$ENV{LOCALAPPDATA}/Programs/dlt-viewer" CMAKE_INSTALL_PREFIX)
-        set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE PATH "..." FORCE)
-    endif()
-
-    if(NOT DLT_PLUGIN_INSTALLATION_PATH)
-        set(DLT_PLUGIN_INSTALLATION_PATH "plugins")
-    endif()
-    if(NOT DLT_RESOURCE_INSTALLATION_PATH)
-        set(DLT_RESOURCE_INSTALLATION_PATH ".")
-    endif()
-    if(NOT DLT_EXECUTABLE_INSTALLATION_PATH)
-        set(DLT_EXECUTABLE_INSTALLATION_PATH ".")
-    endif()
-    if(NOT DLT_LIBRARY_INSTALLATION_PATH)
-        set(DLT_LIBRARY_INSTALLATION_PATH ".")
-    endif()
-endif()
-
-if(OVERWRITE_PLUGIN_INSTALLATION_PATH)
-    set(PLUGIN_INSTALLATION_PATH ${OVERWRITE_PLUGIN_INSTALLATION_PATH})
-else()
-    set(PLUGIN_INSTALLATION_PATH ${DLT_PLUGIN_INSTALLATION_PATH})
-endif()
-
-option(DLT_PARSER "Build DLT Parser" OFF)
-
-if(DLT_PARSER)
-    add_subdirectory(parser)
-endif()
-
-add_subdirectory(qdlt)
-add_subdirectory(src)
-add_subdirectory(plugin)
-add_subdirectory(commander)
-
-message(STATUS "\n\t** DLT Viewer Build Summary **")
-message(STATUS "\tCMAKE_INSTALL_PREFIX:         ${CMAKE_INSTALL_PREFIX}")
-message(STATUS "\tCMAKE_BUILD_TYPE:             ${CMAKE_BUILD_TYPE}")
-message(STATUS "\tCMAKE_SYSTEM_PROCESSOR:       ${CMAKE_SYSTEM_PROCESSOR}")
-message(STATUS "\tCMAKE_SYSTEM_NAME:            ${CMAKE_SYSTEM_NAME}")
-message(STATUS "\tDLT_QT_LIB_DIR:               ${DLT_QT_LIB_DIR}\n")
-
-# Must be last
-include(scripts/windows/package.cmake)
-include(scripts/linux/package.cmake)
-include(scripts/darwin/package.cmake)
+# dltv2fileraw test configures its working directory to use test data file located in the source dir
+add_test(
+  NAME test_dltv2fileraw
+  COMMAND $<TARGET_FILE:test_dltv2fileraw> 
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_executable(test_dltv2fileraw
+    test_dltv2fileraw.cpp
+)
+target_link_libraries(
+  test_dltv2fileraw
+  PRIVATE
+    GTest::gtest_main
+    qdlt
+)

--- a/ecutree.cpp
+++ b/ecutree.cpp
@@ -1,0 +1,16 @@
+#include "ecutree.h"
+
+void EcuTree::add(const QString& ecuId, const qdlt::msg::payload::GetLogInfo& info)
+{
+    for (const auto& app : info.apps) {
+        auto &appData = ecus[ecuId][app.id];
+        appData.description = app.description;
+        for (const auto& ctx : app.ctxs) {
+            Ctx ctxData;
+            ctxData.description = ctx.description;
+            ctxData.logLevel = ctx.logLevel;
+            ctxData.traceStatus = ctx.traceStatus;
+            appData.contexts[ctx.id] = std::move(ctxData);
+        }
+    }
+}

--- a/test_ecutree.cpp
+++ b/test_ecutree.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include <ecutree.h>
+
+namespace {
+
+qdlt::msg::payload::GetLogInfo makeGetLogInfo(
+    const QString &appId,
+    const QString &appDesc,
+    const QString &ctxId,
+    const QString &ctxDesc,
+    int8_t logLevel = 1,
+    int8_t traceStatus = 1)
+{
+    qdlt::msg::payload::GetLogInfo info;
+    info.status = 7;
+
+    qdlt::msg::payload::GetLogInfo::App app;
+    app.id = appId;
+    app.description = appDesc;
+
+    qdlt::msg::payload::GetLogInfo::App::Ctx ctx;
+    ctx.id = ctxId;
+    ctx.description = ctxDesc;
+    ctx.logLevel = logLevel;
+    ctx.traceStatus = traceStatus;
+
+    app.ctxs.push_back(ctx);
+    info.apps.push_back(app);
+    return info;
+}
+
+} // namespace
+
+TEST(EcuTree, PreservesContextsFromMultipleGetLogInfoMessagesForSameApp)
+{
+    EcuTree tree;
+
+    tree.add("IDCE", makeGetLogInfo("APP1", "Application 1", "CTX1", "Context 1"));
+    tree.add("IDCE", makeGetLogInfo("APP1", "Application 1", "CTX2", "Context 2"));
+
+    ASSERT_TRUE(tree.ecus.contains("IDCE"));
+    const auto &apps = tree.ecus.at("IDCE");
+
+    ASSERT_TRUE(apps.contains("APP1"));
+    const auto &app = apps.at("APP1");
+
+    EXPECT_EQ(app.description, "Application 1");
+    EXPECT_EQ(app.contexts.size(), 2u);
+    EXPECT_TRUE(app.contexts.contains("CTX1"));
+    EXPECT_TRUE(app.contexts.contains("CTX2"));
+    EXPECT_EQ(app.contexts.at("CTX1").description, "Context 1");
+    EXPECT_EQ(app.contexts.at("CTX2").description, "Context 2");
+}


### PR DESCRIPTION
Fix EcuTree app merge logic to avoid overwriting APID contexts when multiple GetLogInfo control messages are parsed from a log file. This restores full APID->CTID trees used by Config tab and Save IDs as CSV export.

Add a regression test covering repeated GetLogInfo messages for the same APID with different CTIDs.