### PR TITLE
Plugin pane filename in sync with plugin widget filename

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6795,6 +6795,11 @@ void MainWindow::on_action_menuPlugin_Edit_triggered() {
         dlg.setPluginInterfaceVersion(item->getPluginInterfaceVersion());
         dlg.setFilename(item->getFilename());
         dlg.setMode(item->getMode());
+        // Keep dialog filename in sync with the value currently shown in plugin view.
+        const QString displayedFilename = item->text(2);
+        if (item->getFilename() != displayedFilename) {
+            item->setFilename(displayedFilename);
+        }
         if(!item->getPlugin()->isViewer())
             dlg.removeMode(2); // remove show mode, if no viewer plugin
         dlg.setType(item->getType());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6793,13 +6793,13 @@ void MainWindow::on_action_menuPlugin_Edit_triggered() {
         dlg.setName(item->getName());
         dlg.setPluginVersion(item->getPluginVersion());
         dlg.setPluginInterfaceVersion(item->getPluginInterfaceVersion());
-        dlg.setFilename(item->getFilename());
         dlg.setMode(item->getMode());
         // Keep dialog filename in sync with the value currently shown in plugin view.
         const QString displayedFilename = item->text(2);
         if (item->getFilename() != displayedFilename) {
             item->setFilename(displayedFilename);
         }
+        dlg.setFilename(item->getFilename());
         if(!item->getPlugin()->isViewer())
             dlg.removeMode(2); // remove show mode, if no viewer plugin
         dlg.setType(item->getType());


### PR DESCRIPTION
Ensure filename is visible and consistent in plugin pane and dialog by syncing displayed filename in pane.

Signed off by: Pavithra Anand Pavithra.AA.Anand@bti.bmwgroup.com