### PR TITLE
Fail safely on malformed DLT filter files

### DIFF
--- a/qdlt/qdltdefaultfilter.cpp
+++ b/qdlt/qdltdefaultfilter.cpp
@@ -43,6 +43,9 @@ QDltDefaultFilter::~QDltDefaultFilter()
 
 void QDltDefaultFilter::clear()
 {
+    malformedFilterFiles.clear();
+    malformedFilterErrors.clear();
+
     /* delete all filter list entries */
     QDltFilterList *t;
     foreach(t,defaultFilterList)
@@ -80,7 +83,15 @@ void QDltDefaultFilter::loadDirectory(QString path)
     {
         /* create filter list for every filter file and load the filter file */
         QDltFilterList *filterList = new QDltFilterList();
-        filterList->LoadFilter(dir.absolutePath()+"/"+fileName,true);
+        if(!filterList->LoadFilter(dir.absolutePath()+"/"+fileName,true))
+        {
+            const QString malformedFile = dir.absolutePath()+"/"+fileName;
+            qWarning() << "Skipping malformed default filter file" << malformedFile;
+            malformedFilterFiles.append(malformedFile);
+            malformedFilterErrors.append(filterList->getLastLoadError());
+            delete filterList;
+            continue;
+        }
         defaultFilterList.append(filterList);
 
         /* add empty index for every filter list */

--- a/qdlt/qdltdefaultfilter.h
+++ b/qdlt/qdltdefaultfilter.h
@@ -80,6 +80,12 @@ public:
     /* Default Filter Index */
     QList<QDltFilterIndex*> defaultFilterIndex;
 
+    /* Malformed default filter files skipped during the last load. */
+    QStringList malformedFilterFiles;
+
+    /* Detailed error text for malformed default filter files. */
+    QStringList malformedFilterErrors;
+
 protected:
 private:
 

--- a/qdlt/qdltfilterlist.cpp
+++ b/qdlt/qdltfilterlist.cpp
@@ -52,6 +52,7 @@ QDltFilterList& QDltFilterList::operator= (QDltFilterList const& _filterList)
 {
     QDltFilter *filter_source,*filter_copy;
     clearFilter();
+    lastLoadError = _filterList.lastLoadError;
     for(int numfilter=0;numfilter<_filterList.filters.size();numfilter++)
     {
         filter_copy = new QDltFilter();
@@ -304,22 +305,19 @@ QByteArray QDltFilterList::createMD5()
 }
 
 bool QDltFilterList::LoadFilter(QString _filename, bool replace){
-    bool retVal = true;
-
     QFile file(_filename);
+
+    lastLoadError.clear();
 
     if (!file.open(QFile::ReadOnly | QFile::Text))
     {
+        lastLoadError = file.errorString();
 
         return false;
     }
 
-    filename = _filename; // filename is a private member
-
     QDltFilter filter;
-
-    if(replace)
-        filters.clear();
+    QList<QDltFilter*> loadedFilters;
 
     QXmlStreamReader xml(&file);
     while (!xml.atEnd()) {
@@ -340,23 +338,45 @@ bool QDltFilterList::LoadFilter(QString _filename, bool replace){
               {
                     QDltFilter *filter_new = new QDltFilter();
                     *filter_new = filter;
-                    filters.append(filter_new);
+                    loadedFilters.append(filter_new);
               }
 
           }
     }
     if (xml.hasError())
     {
-     qDebug() << "Error in processing filter file" << filename << xml.errorString();
-     retVal = false;
+         lastLoadError = QString("%1 (line %2, column %3)")
+             .arg(xml.errorString())
+             .arg(xml.lineNumber())
+             .arg(xml.columnNumber());
+
+     qDebug() << "Error in processing filter file" << _filename << xml.errorString();
+
+     for (int numfilter = 0; numfilter < loadedFilters.size(); ++numfilter)
+     {
+         delete loadedFilters[numfilter];
+     }
+
+     file.close();
+     return false;
     }
 
     file.close();
 
+    if(replace)
+        clearFilter();
+
+    for (int numfilter = 0; numfilter < loadedFilters.size(); ++numfilter)
+    {
+        filters.append(loadedFilters[numfilter]);
+    }
+
+    filename = _filename; // filename is a private member
+
     /* update sorted filter list immediately after loading new filter */
     updateSortedFilter();
 
-    return retVal;
+    return true;
 }
 
 void QDltFilterList::updateSortedFilter()

--- a/qdlt/qdltfilterlist.h
+++ b/qdlt/qdltfilterlist.h
@@ -125,6 +125,9 @@ public:
     */
     QString getFilename() const { return filename; }
 
+    //! Return the last filter loading error, if any.
+    QString getLastLoadError() const { return lastLoadError; }
+
     //! Update the presorted list for performance improvement.
     /*!
     */
@@ -154,6 +157,9 @@ private:
 
     //! List of nfilters.
     QList<QDltFilter*> nfilters;
+
+    //! Last filter loading error text including parser context.
+    QString lastLoadError;
 
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -922,17 +922,6 @@ void MainWindow::initFileHandling()
                 filterUpdate();
                 setCurrentFilters(filter);
             }
-            else
-            {
-               if (QDltOptManager::getInstance()->issilentMode())
-                {
-                    qDebug() << "Loading DLT Filter file failed!";
-                }
-                else
-                {
-                    QMessageBox::critical(0, QString("DLT Viewer"),QString("Loading DLT Filter file failed!"));
-                }
-            }
         }
     }
 
@@ -3012,10 +3001,6 @@ bool MainWindow::openDlfFile(QString fileName,bool replace)
         applyConfigEnabled(true);
         on_filterWidget_itemSelectionChanged();
         ui->tabWidget->setCurrentWidget(ui->tabPFilter);
-    }
-    else
-    {
-        QMessageBox::critical(0, QString("DLT Viewer"),QString("Loading DLT Filter file failed!"));
     }
     return true;
 }
@@ -8566,6 +8551,31 @@ void MainWindow::on_actionDefault_Filter_Reload_triggered()
 
     /* load the default filter list */
     defaultFilter.load(dir.absolutePath());
+
+    if(!QDltOptManager::getInstance()->issilentMode() && !defaultFilter.malformedFilterFiles.isEmpty())
+    {
+        QStringList malformedFilterDescriptions;
+        for (int numFilter = 0; numFilter < defaultFilter.malformedFilterFiles.size(); ++numFilter)
+        {
+            QString description = defaultFilter.malformedFilterFiles.at(numFilter);
+            if (numFilter < defaultFilter.malformedFilterErrors.size() && !defaultFilter.malformedFilterErrors.at(numFilter).isEmpty())
+            {
+                description.append(QString("
+  %1").arg(defaultFilter.malformedFilterErrors.at(numFilter)));
+            }
+            malformedFilterDescriptions.append(description);
+        }
+
+        QMessageBox::warning(
+            this,
+            QString("DLT Viewer"),
+            QString("The following default filter file(s) contain errors and were skipped:
+
+%1")
+                .arg(malformedFilterDescriptions.join("
+
+")));
+    }
 
     // default filter list update combobox
     for (const auto *filterList : defaultFilter.defaultFilterList) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8560,8 +8560,7 @@ void MainWindow::on_actionDefault_Filter_Reload_triggered()
             QString description = defaultFilter.malformedFilterFiles.at(numFilter);
             if (numFilter < defaultFilter.malformedFilterErrors.size() && !defaultFilter.malformedFilterErrors.at(numFilter).isEmpty())
             {
-                description.append(QString("
-  %1").arg(defaultFilter.malformedFilterErrors.at(numFilter)));
+                description.append(QString("\n  %1").arg(defaultFilter.malformedFilterErrors.at(numFilter)));
             }
             malformedFilterDescriptions.append(description);
         }
@@ -8569,12 +8568,8 @@ void MainWindow::on_actionDefault_Filter_Reload_triggered()
         QMessageBox::warning(
             this,
             QString("DLT Viewer"),
-            QString("The following default filter file(s) contain errors and were skipped:
-
-%1")
-                .arg(malformedFilterDescriptions.join("
-
-")));
+            QString("The following default filter file(s) contain errors and were skipped:\n\n%1")
+                .arg(malformedFilterDescriptions.join("\n\n")));
     }
 
     // default filter list update combobox

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -1176,13 +1176,21 @@ bool Project::LoadFilter(QString filename, bool replace){
 
     if(!filterList.LoadFilter(filename,replace))
     {
+        QString errorMessage = QString("Loading DLT Filter file failed:\n%1")
+            .arg(filename);
+
+        if (!filterList.getLastLoadError().isEmpty())
+        {
+            errorMessage.append(QString("\n\n%1").arg(filterList.getLastLoadError()));
+        }
+
         if ( QDltOptManager::getInstance()->issilentMode() == false )
         {
-            QMessageBox::critical(0, QString("DLT Viewer"),QString("Loading DLT Filter file failed!"));
+            QMessageBox::critical(0, QString("DLT Viewer"), errorMessage);
         }
         else
         {
-            qDebug() << "Loading" << filterList.getFilename() << " DLT Filter file failed !";
+            qDebug() << errorMessage;
         }
         return false;
     }


### PR DESCRIPTION
## Summary

This change makes malformed DLT filter files fail safely and report the actual parser error to GUI users.

## Regressions Fixed

- Loading a malformed `.dlf` file no longer leaves partially parsed filter entries behind.
- Reloading a default filter directory now skips malformed files instead of treating them like valid filter lists.
- GUI users now get an English warning with the affected file name and parser details both for skipped default filters and for manual `Filter -> Load` failures.

## Implementation

- Make `QDltFilterList::LoadFilter()` atomic by collecting parsed filters in a temporary list and only committing them on successful XML parsing.
- Store the last parser error text, including line and column information, on the filter list.
- Record malformed default filter files during directory load and show a warning dialog after the load finished.
- Reuse the stored parser error text in `Project::LoadFilter()` so manual filter loading shows a detailed error dialog instead of a generic failure message.

## Testing

- Built the isolated branch successfully on Windows with Qt 6.7.2 and MSVC 2019:
  - `cmake -S C:\dlt_devel\01_tmp\covesa-filterfile-pr -B C:\dlt_devel\01_tmp\covesa-filterfile-pr\build\Release -DCMAKE_PREFIX_PATH=C:\Qt\6.7.2\msvc2019_64`
  - `cmake --build C:\dlt_devel\01_tmp\covesa-filterfile-pr\build\Release --target dlt-viewer --config Release`
- Verified editor diagnostics are clean for the touched files.
- Covered the malformed default-filter startup path and the manual `Filter -> Load` failure path in the implementation so both surface the parser details to GUI users while silent mode stays log-only.