### PR TITLE
Short-circuit filter rejects before decode

### DIFF
--- a/qdlt/qdltfilterlist.cpp
+++ b/qdlt/qdltfilterlist.cpp
@@ -33,6 +33,109 @@ extern "C"
 #include "dlt_common.h"
 }
 
+namespace {
+enum class FilterMatchState { Match, Reject, NeedsDecode };
+
+bool matchesMetadataOnly(const QDltFilter *filter, const QDltMsg &msg)
+{
+    const QString msgEcuid = msg.getEcuid();
+    const QString msgApid = msg.getApid();
+    const QString msgCtid = msg.getCtid();
+
+    if(filter->enableEcuid && (msgEcuid != filter->ecuid))
+    {
+        return false;
+    }
+
+    if(filter->enableRegexp_Appid)
+    {
+        if(filter->enableApid && !filter->appidRegularExpression.match(msgApid).hasMatch())
+        {
+            return false;
+        }
+    }
+    else
+    {
+        if(filter->enableApid && (msgApid != filter->apid))
+        {
+            return false;
+        }
+    }
+
+    if(filter->enableRegexp_Context)
+    {
+        if(filter->enableCtid && !filter->contextRegularExpression.match(msgCtid).hasMatch())
+        {
+            return false;
+        }
+    }
+    else
+    {
+        if(filter->enableCtid && !msgCtid.contains(filter->ctid))
+        {
+            return false;
+        }
+    }
+
+    if(filter->enableMessageId)
+    {
+        if(filter->messageIdMax == 0)
+        {
+            if(msg.getMessageId() != filter->messageIdMin)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if((msg.getMessageId() < filter->messageIdMin) ||
+               (msg.getMessageId() >= filter->messageIdMax))
+            {
+                return false;
+            }
+        }
+    }
+
+    if(filter->enableCtrlMsgs && (msg.getType() != QDltMsg::DltTypeControl))
+    {
+        return false;
+    }
+    if(filter->enableLogLevelMax && !((msg.getType() == QDltMsg::DltTypeLog) && (msg.getSubtype() <= filter->logLevelMax)))
+    {
+        return false;
+    }
+    if(filter->enableLogLevelMin && !((msg.getType() == QDltMsg::DltTypeLog) && (msg.getSubtype() >= filter->logLevelMin)))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool requiresDecodedText(const QDltFilter *filter)
+{
+    return filter->enableHeader ||
+           filter->enableRegexp_Header ||
+           filter->enablePayload ||
+           filter->enableRegexp_Payload;
+}
+
+FilterMatchState matchBeforeDecode(const QDltFilter *filter, const QDltMsg &msg)
+{
+    if(!matchesMetadataOnly(filter, msg))
+    {
+        return FilterMatchState::Reject;
+    }
+
+    if(requiresDecodedText(filter))
+    {
+        return FilterMatchState::NeedsDecode;
+    }
+
+    return FilterMatchState::Match;
+}
+}
+
 QDltFilterList::QDltFilterList()
 {
 
@@ -237,6 +340,63 @@ bool QDltFilterList::checkFilter(QDltMsg &msg)
       }
 
     return found;
+}
+
+QDltFilterList::PreDecodeDecision QDltFilterList::checkFilterBeforeDecode(const QDltMsg &msg) const
+{
+    const bool positiveFiltersActive = !pfilters.isEmpty();
+    bool positiveMatched = !positiveFiltersActive;
+    bool positiveNeedsDecode = false;
+
+    for(int numfilter = 0; numfilter < pfilters.size(); numfilter++)
+    {
+        switch(matchBeforeDecode(pfilters[numfilter], msg))
+        {
+        case FilterMatchState::Match:
+            positiveMatched = true;
+            break;
+        case FilterMatchState::NeedsDecode:
+            positiveNeedsDecode = true;
+            break;
+        case FilterMatchState::Reject:
+            break;
+        }
+
+        if(positiveMatched)
+        {
+            break;
+        }
+    }
+
+    bool negativeNeedsDecode = false;
+    if(positiveMatched || positiveNeedsDecode)
+    {
+        for(int numfilter = 0; numfilter < nfilters.size(); numfilter++)
+        {
+            switch(matchBeforeDecode(nfilters[numfilter], msg))
+            {
+            case FilterMatchState::Match:
+                return PreDecodeDecision::Reject;
+            case FilterMatchState::NeedsDecode:
+                negativeNeedsDecode = true;
+                break;
+            case FilterMatchState::Reject:
+                break;
+            }
+        }
+    }
+
+    if(!positiveMatched && !positiveNeedsDecode)
+    {
+        return PreDecodeDecision::Reject;
+    }
+
+    if(positiveMatched && !negativeNeedsDecode)
+    {
+        return PreDecodeDecision::Match;
+    }
+
+    return PreDecodeDecision::NeedsDecode;
 }
 
 bool QDltFilterList::SaveFilter(QString _filename)

--- a/qdlt/qdltfilterlist.h
+++ b/qdlt/qdltfilterlist.h
@@ -40,6 +40,8 @@ class QDLT_EXPORT QDltFilterList
 {
 public:
 
+  enum class PreDecodeDecision { Match, Reject, NeedsDecode };
+
     //! List of filters.
     QList<QDltFilter*> filters;
 
@@ -104,6 +106,10 @@ public:
       \return true if message will be displayed, false if message will be filtered out
     */
     bool checkFilter(QDltMsg &msg);
+
+    //! Check if message can already be accepted or rejected from raw metadata.
+    /*! Returns NeedsDecode if header or payload conditions still need the full matcher path. */
+    PreDecodeDecision checkFilterBeforeDecode(const QDltMsg &msg) const;
 
     //! Save the filter.
     /*!

--- a/src/dltfileindexerthread.cpp
+++ b/src/dltfileindexerthread.cpp
@@ -56,6 +56,12 @@ void DltFileIndexerThread::processMessage(QSharedPointer<QDltMsg> &msg, int inde
     bool pluginsEnabled = indexer->getPluginsEnabled();
     QDltPlugin *item;
     bool bool_result = false;
+    QDltFilterList::PreDecodeDecision preDecodeDecision = QDltFilterList::PreDecodeDecision::NeedsDecode;
+
+    if(mode == DltFileIndexer::modeIndexAndFilter)
+    {
+        preDecodeDecision = filterList->checkFilterBeforeDecode(*msg);
+    }
 
     /* check if it is a version messages and
     version string not already parsed */
@@ -117,13 +123,28 @@ void DltFileIndexerThread::processMessage(QSharedPointer<QDltMsg> &msg, int inde
     }
 
     /* Process all decoderplugins */
-    if ( pluginsEnabled == true )
-     {
-     (void) pluginManager->decodeMsg(*msg, silentMode);
-     }
+    const bool skipDecodeForRejectedMessage =
+        pluginsEnabled &&
+        activeViewerPlugins->isEmpty() &&
+        (preDecodeDecision == QDltFilterList::PreDecodeDecision::Reject);
 
+    if(pluginsEnabled && !skipDecodeForRejectedMessage)
+    {
+        (void) pluginManager->decodeMsg(*msg, silentMode);
+    }
 
-    bool_result = filterList->checkFilter(*msg);
+    switch(preDecodeDecision)
+    {
+    case QDltFilterList::PreDecodeDecision::Match:
+        bool_result = true;
+        break;
+    case QDltFilterList::PreDecodeDecision::Reject:
+        bool_result = false;
+        break;
+    case QDltFilterList::PreDecodeDecision::NeedsDecode:
+        bool_result = filterList->checkFilter(*msg);
+        break;
+    }
     if ( bool_result == true)
     {
         if(const QDltFilter *markerFilter = filterList->matchMarkerFilter(*msg); markerFilter != nullptr)


### PR DESCRIPTION
## Summary

- add a metadata-only prefilter path in `QDltFilterList`
- decide `Match` / `Reject` / `NeedsDecode` before the normal filter matcher runs
- skip decoder work for messages that are already definite rejects when no viewer plugin needs decoded message callbacks

## Why

Applying a loaded filter file currently pushes every message through the decode path before the filter decision is known. For common filters that only look at ECU/APID/CTID/message id/type/level metadata, that work is unnecessary.

This change keeps header, payload, and regexp-on-decoded-text filters on the existing full matcher path, but short-circuits the obvious metadata-only rejects early.

## Validation

- `get_errors` clean on `qdlt/qdltfilterlist.h`, `qdlt/qdltfilterlist.cpp`, and `src/dltfileindexerthread.cpp`
- clean Qt6/MSVC build succeeded in `C:\dlt_devel\01_tmp\covesa-filter-prefilter-pr-20260611\build\Release`
- user stopwatch results on the preferred stand `C:\dlt_devel\01_tmp\qt6_covesa_filterhot_20260611_prefilter`:
  - `gernot_network.dlf`: `1:11`
  - `Lifecycle_gernot`: `1:06`
  - `message_buffer_overflow`: `0:59`

## Notes

- this is the validated winning step only; the later sync-message reuse experiment was intentionally not included because it regressed the first real filter case