### PR TITLE
Allow plugins to enable multiple file/directory selection

### DIFF
--- a/qdlt/plugininterface.h
+++ b/qdlt/plugininterface.h
@@ -28,7 +28,7 @@
 
 #include <QString>
 
-#define PLUGIN_INTERFACE_VERSION "1.0.1"
+#define PLUGIN_INTERFACE_VERSION "1.1.0"
 
 class QTableView;
 
@@ -115,6 +115,20 @@ public:
     */
     virtual QStringList infoConfig() = 0;
 
+    //! Whether the plugin configuration dialog may select multiple files/directories.
+    /*!
+      By default, the generic plugin configuration dialog only lets the user
+      pick a single file or a single directory, which is passed as-is to
+      loadConfig()/saveConfig(). Plugins whose loadConfig()/saveConfig()
+      implementation can handle several paths at once may override this to
+      return true; the dialog will then allow selecting multiple files
+      (or accumulating multiple directories) and join them into a single
+      string separated by '|' before passing it to loadConfig()/saveConfig().
+      This feature is disabled by default and must be explicitly enabled by
+      the plugin.
+      \return True if the plugin supports multiple files/directories, false (default) otherwise.
+    */
+    virtual bool allowsMultipleFiles() { return false; }
 
 };
 

--- a/qdlt/qdltplugin.cpp
+++ b/qdlt/qdltplugin.cpp
@@ -120,6 +120,14 @@ QString QDltPlugin::pluginInterfaceVersion()
         return QString();
 }
 
+bool QDltPlugin::allowsMultipleFiles()
+{
+    if(plugininterface)
+        return plugininterface->allowsMultipleFiles();
+    else
+        return false;
+}
+
 QString QDltPlugin::error()
 {
     if(plugininterface)

--- a/qdlt/qdltplugin.h
+++ b/qdlt/qdltplugin.h
@@ -79,6 +79,13 @@ public:
     QStringList infoConfig();
 
     // viewer plugin interfaces
+    /*!
+      Disabled by default; plugins must opt in via QDLTPluginInterface::allowsMultipleFiles().
+      \return True if the plugin supports multiple files/directories.
+    */
+    bool allowsMultipleFiles();
+
+    // viewer plugin interfaces
     QWidget* initViewer();
     void initFileStart(QDltFile *file);
     void initMsg(int index, QDltMsg &msg);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6798,6 +6798,9 @@ void MainWindow::on_action_menuPlugin_Edit_triggered() {
         if(!item->getPlugin()->isViewer())
             dlg.removeMode(2); // remove show mode, if no viewer plugin
         dlg.setType(item->getType());
+        // Multiple file/directory selection is disabled by default; only
+        // enable it for plugins that explicitly opted in.
+        dlg.setMultiSelectionEnabled(item->getPlugin()->allowsMultipleFiles());
         if(dlg.exec()) {
             /* Check if there was a change that requires a refresh */
             if(item->getMode() != dlg.getMode())

--- a/src/plugindialog.cpp
+++ b/src/plugindialog.cpp
@@ -24,7 +24,8 @@
 
 PluginDialog::PluginDialog(QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::PluginDialog) {
+    ui(new Ui::PluginDialog),
+    multiSelectEnabled(false) {
     ui->setupUi(this);
 }
 
@@ -61,6 +62,10 @@ void PluginDialog::setFilename(QString filename) {
     ui->lineEditFilename->setText(filename);
 }
 
+void PluginDialog::setMultiSelectionEnabled(bool enabled) {
+    multiSelectEnabled = enabled;
+}
+
 int PluginDialog::getMode() {
     return ui->comboBoxMode->currentIndex();
 }
@@ -76,33 +81,64 @@ QString PluginDialog::getFilename() {
 void PluginDialog::on_toolButton_clicked() {
     QString name = ui->lineEditName->text();
     QString fileName;
+    QString lastPickedPath;
 
     if(ui->comboBoxType->currentIndex()==0)
     {
         // filename
-        QStringList fileNames = QFileDialog::getOpenFileNames(this,
-            QString("Open ")+name+QString(" configuration file"),
-            workingDirectory.getPluginDirectory(name),
-            tr("Plugin configuration (*.*)"));
-        if(fileNames.size()==1)
-            fileName = fileNames[0];
-        else if(fileNames.size()>1)
+        if(multiSelectEnabled)
+        {
+            QStringList fileNames = QFileDialog::getOpenFileNames(this,
+                QString("Open ")+name+QString(" configuration file"),
+                workingDirectory.getPluginDirectory(name),
+                tr("Plugin configuration (*.*)"));
+            if(fileNames.isEmpty())
+                return;
             fileName = fileNames.join('|');
+            lastPickedPath = fileNames.first();
+        }
+        else
+        {
+            fileName = QFileDialog::getOpenFileName(this,
+                QString("Open ")+name+QString(" configuration file"),
+                workingDirectory.getPluginDirectory(name),
+                tr("Plugin configuration (*.*)"));
+            lastPickedPath = fileName;
+        }
     }
     else
     {
         // directory
-        fileName = QFileDialog::getExistingDirectory(this,
+        QString dirName = QFileDialog::getExistingDirectory(this,
                                                      QString("Open ")+name+QString(" configuration file"),
                                                      workingDirectory.getPluginDirectory(name),
                                                      QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+        if(dirName.isEmpty())
+            return;
+        lastPickedPath = dirName;
+
+        if(multiSelectEnabled)
+        {
+            // Native dialogs only support picking one directory at a time, so
+            // accumulate directories across repeated clicks of the browse
+            // button instead, joined by '|' (same separator used for multiple
+            // files above).
+            QStringList dirs = ui->lineEditFilename->text().split('|', Qt::SkipEmptyParts);
+            if(!dirs.contains(dirName))
+                dirs.append(dirName);
+            fileName = dirs.join('|');
+        }
+        else
+        {
+            fileName = dirName;
+        }
     }
 
     if(fileName.isEmpty())
         return;
 
     /* change current working directory */
-    workingDirectory.setPluginDirectory(name, QFileInfo(fileName).absolutePath());
+    workingDirectory.setPluginDirectory(name, QFileInfo(lastPickedPath).absolutePath());
 
     ui->lineEditFilename->setText(fileName);
 }

--- a/src/plugindialog.h
+++ b/src/plugindialog.h
@@ -46,12 +46,24 @@ public:
     void setType(int type);
     void setFilename(QString filename);
 
+    //! Enable selecting multiple files/directories in the browse dialog.
+    /*!
+      Disabled by default. Callers should enable this only for plugins that
+      declare support for it (see QDLTPluginInterface::allowsMultipleFiles()).
+      When enabled, multiple files can be picked at once and are joined with
+      '|'; directories are accumulated across repeated clicks of the browse
+      button, also joined with '|'.
+      \param enabled True to allow multiple files/directories to be selected.
+    */
+    void setMultiSelectionEnabled(bool enabled);
+
     int getMode();
     int getType();
     QString getFilename();
 
 private:
     Ui::PluginDialog *ui;
+    bool multiSelectEnabled;
 
 private slots:
     void on_toolButton_clicked();


### PR DESCRIPTION
Some plugins might need informations from multiple input files or directories. These can override the `allowsMultipleFiles` method and return `true` to enable multiple file/directory selection.

Note: While selecting multiple files is possible in a single selection step, selecting multiple directories can only be done by subsequent selection steps.