### PR TITLE
Fix CLI plugin configuration and read-only log handling

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1140,19 +1140,33 @@ void MainWindow::commandLineExecutePlugin(QString name, QString cmd, QStringList
         exit(-1);
     }
 
-    // Special handling for the non-verbose decoder plugin when used from
-    // the command line:
-    //
-    // The "fibex_path" command only stores the configured path inside the
-    // plugin. To actually load and parse the Fibex data before any
-    // decoding or exporting happens, we need to trigger its loadConfig()
-    // once the command has been processed. Passing an empty filename lets
-    // the plugin use the path set via the command.
     if (plugin->isDecoder()
-            && plugin->name() == QLatin1String("Non Verbose Mode Plugin")
             && cmd.compare(QLatin1String("fibex_path"), Qt::CaseInsensitive) == 0)
     {
-        plugin->loadConfig(QString());
+        const QString configPath = params.isEmpty() ? QString() : params.at(0);
+        // Non Verbose plugin stores the path without parsing it in command(), other decoder plugins already loaded it above.
+        if (plugin->name() == QLatin1String("Non Verbose Mode Plugin")
+                && !plugin->loadConfig(QString()))
+        {
+            QString msg("Error: ");
+            msg.append(name);
+            msg.append(plugin->error());
+            ErrorMessage(QMessageBox::Warning,name, msg);
+            exit(-1);
+        }
+
+        if (configPath.isEmpty())
+            return;
+
+        for(int num = 0; num < project.plugin->topLevelItemCount (); num++)
+        {
+            PluginItem *pluginitem = (PluginItem*)project.plugin->topLevelItem(num);
+            if(pluginitem->getPlugin() == plugin)
+            {
+                pluginitem->setFilename(configPath);
+                break;
+            }
+        }
     }
 }
 
@@ -1485,17 +1499,14 @@ bool MainWindow::openDltFile(QStringList fileNames)
     /* open existing file and append new data */
     outputfile.setFileName(fileNames.last());
     setCurrentFile(fileNames.last());
-    if( true == outputfile.open(QIODevice::WriteOnly|QIODevice::Append) )
+    // CLI mode stays read-only to avoid interfering with the indexer's Windows size query.
+    if( !QDltOptManager::getInstance()->isCommandlineMode()
+            && true == outputfile.open(QIODevice::WriteOnly|QIODevice::Append) )
     {
         openFileNames = fileNames;
         isDltFileReadOnly = false;
         //qDebug() << "Opening file(s) wo" << outputfile.fileName() << __FILE__ << __LINE__;
-        if(QDltOptManager::getInstance()->isCommandlineMode())
-            // if dlt viewer started as converter or with plugin option load file non multithreaded
-            reloadLogFile(false,false);
-        else
-            // normally load log file mutithreaded
-            reloadLogFile();
+        reloadLogFile();
         outputfile.close(); // open later again when writing
         ret = true;
     }
@@ -1519,13 +1530,13 @@ bool MainWindow::openDltFile(QStringList fileNames)
         else
         {
             if (QDltOptManager::getInstance()->issilentMode())
-              {
+            {
                 qDebug() << "Accessing logfile error" << fileNames.last() << outputfile.errorString();
-              }
+            }
             else
-              {
+            {
                 QMessageBox::critical(0, QString("DLT Viewer"), QString("Cannot open log file \"%1\"\n%2").arg(fileNames.last()).arg(outputfile.errorString()));
-              }
+            }
             ret = false;
         }
     }


### PR DESCRIPTION
Add special handling for the fibex_path command when used from CLI: ensure the Non Verbose Mode Plugin actually loads its config, and set the plugin item's filename from the command parameter. Change openDltFile to keep CLI/commandline mode read-only (avoid opening output file for append to not interfere with indexer) and always call reloadLogFile when the file is opened.

Signed off by: Pavithra Anand Pavithra.AA.Anand@bti.bmwgroup.com