### PR TITLE
Unload plugins before QApplication shutdown

### DIFF
--- a/qdlt/qdltpluginmanager.cpp
+++ b/qdlt/qdltpluginmanager.cpp
@@ -8,6 +8,8 @@
 #include <QMutex>
 #include <QTextStream>
 #include <QString>
+#include <QtAlgorithms>
+#include <utility>
 
 #ifndef PLUGIN_INSTALLATION_PATH
 #define PLUGIN_INSTALLATION_PATH ""
@@ -17,6 +19,22 @@ int QDltPluginManager::size() const
 {
     return plugins.size();
 }
+
+QDltPluginManager::~QDltPluginManager()
+{
+    // Delete the plugin objects.
+    qDeleteAll(plugins);
+    // Remove the deleted pointers from the container.
+    plugins.clear();
+
+    for (QPluginLoader *pluginLoader : std::as_const(pluginLoaders))
+    {
+        pluginLoader->unload();
+        delete pluginLoader;
+    }
+    pluginLoaders.clear();
+}
+
 
 QStringList QDltPluginManager::loadPlugins(const QString &settingsPluginPath)
 {
@@ -68,8 +86,9 @@ QStringList QDltPluginManager::loadPluginsPath(QDir &dir)
     /* iterate through all plugins */
     foreach (QString fileName, dir.entryList(QDir::Files))
     {
-        QPluginLoader pluginLoader(dir.absoluteFilePath(fileName));
-        QObject *plugin = pluginLoader.instance();
+        QPluginLoader *pluginLoader = new QPluginLoader(dir.absoluteFilePath(fileName));
+        pluginLoaders.append(pluginLoader);
+        QObject *plugin = pluginLoader->instance();
         if (plugin)
         {
             QDLTPluginInterface *plugininterface = qobject_cast<QDLTPluginInterface *>(plugin);
@@ -110,7 +129,7 @@ QStringList QDltPluginManager::loadPluginsPath(QDir &dir)
             QTextStream  errStr(&s);
             errStr << "-------------"
                     << "The plugin " << dir.absoluteFilePath(fileName) << "cannot be loaded.\n\n"
-                    << "Error: " << pluginLoader.errorString() << "\n";
+                    << "Error: " << pluginLoader->errorString() << "\n";
             errorStrings.append(s);
 
         }

--- a/qdlt/qdltpluginmanager.h
+++ b/qdlt/qdltpluginmanager.h
@@ -16,10 +16,14 @@
 
 class QDltPlugin;
 class QMutex;
+class QPluginLoader;
 
 class QDLT_EXPORT QDltPluginManager : public QDltMessageDecoder
 {
 public:
+    QDltPluginManager() = default;
+    ~QDltPluginManager();
+
     //! The number of plugins
     /*!
       \return the number of loaded plugins.
@@ -89,6 +93,9 @@ private:
 
     //! The list of pointers to all loaded plugins
     QList<QDltPlugin*> plugins;
+
+    //! Keep plugin loaders alive so plugins unload before QApplication shuts down.
+    QList<QPluginLoader*> pluginLoaders;
 
     //! Loads all plugins from a special directory
     QStringList loadPluginsPath(QDir &dir);


### PR DESCRIPTION
- Add lifecycle management for QPluginLoader instances to ensure plugins are unloaded before QApplication teardown.
- Implement QDltPluginManager::~QDltPluginManager() to unload and delete loaders and to qDeleteAll() plugin objects to avoid crashes during Qt object destruction.

Signed off by: Pavithra Anand Pavithra.AA.Anand@bti.bmwgroup.com