### PR TITLE
fix(udp): resolve adapter name to IPv4 address before UDP bind

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3193,6 +3193,27 @@ QStringList MainWindow::getAvailableNetworkInterfaces()
     return network_interface_namelist;
 }
 
+// the ECU dialog offers adapter names (humanReadableName), but binding a socket requires an IP address
+QString MainWindow::resolveInterfaceIPv4(const QString &ifName)
+{
+    QList<QNetworkInterface> interfaces = QNetworkInterface::allInterfaces();
+    for (int num = 0; num < interfaces.length(); num++)
+    {
+        if (interfaces[num].humanReadableName() == ifName)
+        {
+            const QList<QNetworkAddressEntry> entries = interfaces[num].addressEntries();
+            for (const QNetworkAddressEntry &entry : entries)
+            {
+                if (entry.ip().protocol() == QAbstractSocket::IPv4Protocol)
+                {
+                    return entry.ip().toString();
+                }
+            }
+        }
+    }
+    return QString(); // no matching interface / no IPv4 address found
+}
+
 
 void MainWindow::on_action_menuConfig_ECU_Add_triggered()
 {
@@ -4242,6 +4263,20 @@ void MainWindow::connectECU(EcuItem* ecuitem,bool force)
             if ( ecuitem->getEthIF() == "AnyIP")
             {
                 connectIPaddress = "0.0.0.0"; // we need to translate AnyIP to 0.0.0.0 on Linux ...
+            }
+            else
+            {
+                // the interface dropdown stores the adapter name, but bind() needs an IP address
+                QString resolvedIP = resolveInterfaceIPv4(connectIPaddress);
+                if (resolvedIP.isEmpty())
+                {
+                    qDebug() << "Error - could not resolve IPv4 address for interface" << connectIPaddress;
+                    ecuitem->connectError.append("Interface not found");
+                    ecuitem->connected = false;
+                    ecuitem->update();
+                    return;
+                }
+                connectIPaddress = resolvedIP;
             }
 
            /* connect socket signals with window slots */

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -387,6 +387,7 @@ private:
     QStringList getAvailableIPPorts() {return { "3490"};} // DLT standard port
     QStringList getAvailableUDPPorts() {return { "3490"};} // DLT standard port
     QStringList getAvailableNetworkInterfaces();
+    QString resolveInterfaceIPv4(const QString &ifName);
 
     void deleteactualFile();
 


### PR DESCRIPTION
Resolves adapter display name (e.g. "DLT") to its IPv4 address before binding the UDP socket, since QHostAddress cannot parse adapter names directly. Fixes 'Binding failed' errors when the Receiving interface field is set to an adapter name instead of an IP address.

Note on Qt5 vs Qt6 behavior: This bug is reproducible with Qt6 builds (confirmed on 6.8.3) — binding fails with a generic "Unknown error" when the "Receiving interface" field contains an adapter's display name (e.g. "DLT", "CP60") instead of an IP address, because QHostAddress(QString) cannot parse non-numeric strings and leaves the address in a null/UnknownNetworkLayerProtocol state (confirmed in Qt's own qhostaddress.cpp).

Colleagues running official Qt5-based stable releases of DLT Viewer do not observe this failure with the same renamed-interface configuration — the socket bind apparently succeeds despite the same invalid input. This is likely due to differences in Qt5's vs Qt6's underlying socket engine handling of an address with UnknownNetworkLayerProtocol during bind() (Qt6 substantially rewrote the network backend), though the exact code path responsible hasn't been traced. Regardless of the underlying Qt-version-dependent behavior, relying on an unparseable string being silently accepted by bind() was never correct or guaranteed — this fix removes that dependency entirely by resolving the interface name to an actual IPv4 address before binding.