### PR TITLE
Fix live view not updating when connecting a single ECU

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -180,14 +180,19 @@ MainWindow::MainWindow(QWidget *parent) :
         exit(0);
     }
 
+    /* start timer for autoconnect */
+    connect(&timer, SIGNAL(timeout()), this, SLOT(timeout())); // we want to start the timer only when an ECU connection is active
+
+    /* periodic refresh of the live view; started only while an ECU connection is active */
+    connect(&drawTimer, &QTimer::timeout, this, &MainWindow::drawUpdatedView);
+
     /* auto connect */
+    /* must happen after the timers above are wired up, otherwise the timers
+     * started by connectAll() would have no receiver connected yet */
     if( (settings->autoConnect != 0) ) // in convertion mode we do not need any connection ...)
     {
         connectAll();
     }
-
-    /* start timer for autoconnect */
-    connect(&timer, SIGNAL(timeout()), this, SLOT(timeout())); // we want to start the timer only when an ECU connection is active
 
     restoreGeometry(settings->geometry);
     restoreState(settings->windowState);
@@ -4083,17 +4088,10 @@ void MainWindow::connectAll()
         EcuItem *ecuitem = (EcuItem*)project.ecu->topLevelItem(num);
         connectECU(ecuitem);
     }
-
-    // periodically update table view to account for the new incoming messages
-    const int drawInterval = (settings->RefreshRate > 0) ? 1000 / settings->RefreshRate
-                                                         : 1000 / DEFAULT_REFRESH_RATE;
-    drawTimer.start(drawInterval);
-    connect(&drawTimer, &QTimer::timeout, this, &MainWindow::drawUpdatedView);
 }
 
 void MainWindow::disconnectAll()
 {
-    drawTimer.stop();
     for(int num = 0; num < project.ecu->topLevelItemCount (); num++)
     {
         EcuItem *ecuitem = (EcuItem*)project.ecu->topLevelItem(num);
@@ -4105,6 +4103,7 @@ void MainWindow::disconnectAll()
     if(settings && settings->includeManualMarkersInFilter && !isLiveLoggingActive())
         updateManualMarkerUnionInFilter();
 
+    updateDrawTimerState();
     checkConnectionState();
 }
 
@@ -4140,6 +4139,8 @@ void MainWindow::disconnectECU(EcuItem *ecuitem)
     // If this was the last active ECU, switch back to offline marker union (if enabled).
     if(settings && settings->includeManualMarkersInFilter && !isLiveLoggingActive())
         updateManualMarkerUnionInFilter();
+
+    updateDrawTimerState();
 }
 
 void MainWindow::on_action_menuConfig_Connect_triggered()
@@ -4204,6 +4205,8 @@ void MainWindow::connectECU(EcuItem* ecuitem,bool force)
         ecuitem->connected = false;
         ecuitem->update();
         on_configWidget_itemSelectionChanged();
+
+        updateDrawTimerState();
 
         /* reset receive buffer */
         ecuitem->totalBytesRcvd = 0;
@@ -5002,6 +5005,26 @@ void MainWindow::updateIndex()
             item = activeViewerPlugins.at(i);
             item->updateFileFinish();
         }
+    }
+}
+
+void MainWindow::updateDrawTimerState()
+{
+    if(isLiveLoggingActive())
+    {
+        if(!drawTimer.isActive())
+        {
+            // periodically update table view to account for the new incoming messages
+            const int drawInterval = (settings->RefreshRate > 0) ? 1000 / settings->RefreshRate
+                                                                 : 1000 / DEFAULT_REFRESH_RATE;
+            drawTimer.start(drawInterval);
+        }
+    }
+    else if(drawTimer.isActive())
+    {
+        drawTimer.stop();
+        // render whatever arrived between the last tick and the disconnect
+        drawUpdatedView();
     }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -337,6 +337,9 @@ private:
     void updateIndex();
     void drawUpdatedView();
 
+    //! Start/stop the periodic live view refresh depending on connection state.
+    void updateDrawTimerState();
+
     void syncCheckBoxesAndMenu();
 
     void updateRecentFileActions();


### PR DESCRIPTION
Fixes #833.

## Problem

`drawUpdatedView()` refreshes the message table and the `Recv:` / `Recv Errors:` / `Sync found:` status labels. It is driven by `drawTimer`, which was started in exactly one place — `connectAll()`.

Connecting a **single ECU** goes through `connectECU()` (Config → Connect, the ECU context menu, or the toolbar button with an ECU selected), which never started the timer. The result is a completely static GUI: the table stays empty and the counters stay at `0`, even though data is received and written to the log file correctly the whole time.

This is a regression from 6f0c092, which replaced the data-driven single-shot kick at the end of `updateIndex()` with a start in `connectAll()`. The old kick was triggered by arriving data and was therefore connection-path agnostic. Released in 2.30.0.

## Change

The timer start/stop moves into a small helper, `updateDrawTimerState()`, which keys off the existing `isLiveLoggingActive()` predicate and is called from `connectECU()` and `disconnectECU()`. Since `connectAll()`/`disconnectAll()` delegate to those, every connect/disconnect path is now covered, and the timer runs exactly while at least one ECU is live. Stopping also performs a final `drawUpdatedView()` so messages that arrived between the last tick and the disconnect are rendered rather than silently missing from the view.

Two related fixes in the same lines:

* `connect(&drawTimer, ...)` moves to the constructor. Previously it ran on every *Connect All*, so each cycle added another connection to the same signal and `drawUpdatedView()` was invoked N times per tick after N connects.
* The `autoConnect` block in the constructor moves *below* the timer wiring. It called `connectAll()` before `connect(&timer, ...)` had run, so timers started via auto connect had no receiver connected yet.

No behaviour change for the *Connect All* path.

## Verification

Tested against a real ECU producing a continuous DLT stream. A probe `qDebug()` was added at the top of `drawUpdatedView()` in **both** builds, run with `QT_QPA_PLATFORM=offscreen` and an identical isolated `HOME` and project file.

Single-ECU connect (`autoConnect=0`), 30 s per run:

| build | `drawUpdatedView()` calls | rows in table |
| --- | --- | --- |
| `master` (edf7aa5) | **0** | – |
| this PR | **560** | 10392 |

On `master` the receive path was provably healthy at the same time — socket `ESTABLISHED` with a drained receive queue, and the viewer's cache file growing ~120 KB every 3 s (6.6 MB total) — while the GUI showed nothing.

Regression check, *Connect All* with `autoConnect=1`, 25 s per run:

| build | `drawUpdatedView()` calls |
| --- | --- |
| `master` | 498 |
| this PR | 497 |

Builds clean with Qt 5 on Ubuntu 24.04. The probe instrumentation is **not** part of this PR.
