### PR TITLE
Feat/tcp server mode

### DIFF
--- a/diag_dlt.py
+++ b/diag_dlt.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+DLT Viewer TCP Server - 深度诊断脚本
+用法: python diag_dlt.py
+
+配合 Viewer 调试日志使用:
+1. 重新编译 Viewer (已添加 qDebug 日志)
+2. 从命令行启动 Viewer (或在 Qt Creator Debug 模式)
+3. 在 Viewer 中: File → Clear (扫帚图标)
+4. 配置 ECU 为 TCP Server, 端口 3490
+5. **取消勾选 Auto Reconnect** (重要!)
+6. 点击 Connect
+7. 运行本脚本
+8. 对比脚本输出和 Viewer 控制台日志
+"""
+
+import socket
+import struct
+import time
+import sys
+
+HOST = "127.0.0.1"
+PORT = 3490
+
+# DLT constants
+DLT_HTYP_UEH  = 0x01
+DLT_HTYP_MSBF = 0x02
+DLT_HTYP_WEID = 0x04
+DLT_HTYP_WSID = 0x08
+DLT_HTYP_WTMS = 0x10
+DLT_HTYP_VERS = 0x20
+
+DLT_TYPE_LOG  = 1
+DLT_LOG_INFO  = 6
+
+DLT_TYPE_INFO_STRG = 0x0200
+DLT_TYPE_INFO_BOOL = 0x0400
+DLT_TYPE_INFO_SINT = 0x0800
+DLT_TYPE_INFO_UINT = 0x1000
+
+SERIAL_HEADER = b"DLS\x01"
+
+_msg_counter = 0
+
+
+def build_dlt_log_msg(ecuid, apid, ctid, text):
+    """构建一条 DLT 非详细日志消息"""
+    global _msg_counter
+    _msg_counter += 1
+
+    payload = struct.pack(">I", DLT_TYPE_INFO_STRG)
+    text_bytes = text.encode("utf-8")
+    payload += struct.pack(">H", len(text_bytes) + 1)
+    payload += text_bytes + b"\x00"
+
+    noar = 1
+    msin = (DLT_TYPE_LOG << 1) | DLT_LOG_INFO
+
+    ecu = ecuid.encode("ascii").ljust(4, b"\x00")[:4]
+    apid_b = apid.encode("ascii").ljust(4, b"\x00")[:4]
+    ctid_b = ctid.encode("ascii").ljust(4, b"\x00")[:4]
+    sid = struct.pack(">I", _msg_counter)
+    tmsp = struct.pack(">I", _msg_counter * 1000)
+
+    htyp = DLT_HTYP_VERS | DLT_HTYP_UEH | DLT_HTYP_MSBF | DLT_HTYP_WEID | DLT_HTYP_WSID | DLT_HTYP_WTMS
+    mcnt = _msg_counter & 0xFF
+    # len = standard_header(4) + extra(12) + extended_header(10) + payload
+    total_len = 4 + 12 + 10 + len(payload)
+
+    msg = SERIAL_HEADER
+    msg += struct.pack("B", htyp)
+    msg += struct.pack("B", mcnt)
+    msg += struct.pack(">H", total_len)
+    msg += ecu
+    msg += sid
+    msg += tmsp
+    msg += struct.pack("B", msin)
+    msg += struct.pack("B", noar)
+    msg += apid_b
+    msg += ctid_b
+    msg += payload
+
+    return msg
+
+
+def hex_dump(data, prefix=""):
+    lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i:i+16]
+        hex_part = " ".join(f"{b:02x}" for b in chunk)
+        ascii_part = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+        lines.append(f"{prefix}  {i:04x}: {hex_part:<48s} {ascii_part}")
+    return "\n".join(lines)
+
+
+def main():
+    print("=" * 60)
+    print("DLT Viewer TCP Server 深度诊断")
+    print("=" * 60)
+    print()
+
+    # Build test message
+    msg = build_dlt_log_msg("ECU1", "TEST", "INFO", "Hello DLT Viewer!")
+    print(f"DLT 消息 ({len(msg)} bytes):")
+    print(hex_dump(msg))
+    print()
+
+    # Connect
+    print(f"连接 {HOST}:{PORT} ...")
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(10)
+        sock.connect((HOST, PORT))
+        print("[OK] 连接成功!")
+    except Exception as e:
+        print(f"[FAIL] 连接失败: {e}")
+        sys.exit(1)
+
+    # Send multiple messages with 500ms interval
+    num_msgs = 20
+    interval = 0.5
+    sent = 0
+    errors = 0
+
+    print(f"\n发送 {num_msgs} 条消息, 间隔 {interval}s ...")
+    print("-" * 40)
+
+    for i in range(num_msgs):
+        t = time.time()
+        try:
+            sock.send(msg)
+            sent += 1
+            elapsed = time.time() - t
+            print(f"  [{i+1:2d}/{num_msgs}] 发送成功 ({len(msg)} bytes, {elapsed*1000:.1f}ms)")
+        except Exception as e:
+            errors += 1
+            print(f"  [{i+1:2d}/{num_msgs}] 发送失败: {e}")
+            # Try reconnect
+            try:
+                sock.close()
+            except:
+                pass
+            time.sleep(1)
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(10)
+                sock.connect((HOST, PORT))
+                print(f"         -> 重连成功!")
+                sock.send(msg)
+                sent += 1
+                errors -= 1  # undo error count since resend succeeded
+            except Exception as e2:
+                print(f"         -> 重连失败: {e2}")
+                break
+
+        time.sleep(interval)
+
+    print("-" * 40)
+    print(f"发送完成: 成功={sent}, 失败={errors}")
+
+    # Check final connection state
+    try:
+        sock.settimeout(1)
+        data = sock.recv(4096)
+        if data:
+            print(f"\n收到 Viewer 数据 ({len(data)} bytes):")
+            print(hex_dump(data, "  "))
+        else:
+            print("\n连接已关闭 (recv 返回空)")
+    except socket.timeout:
+        print("\n连接仍然存活 (recv 超时=无数据)")
+    except Exception as e:
+        print(f"\n连接异常: {e}")
+
+    try:
+        sock.close()
+    except:
+        pass
+
+    print()
+    print("=" * 60)
+    print("下一步:")
+    print("1. 查看 DLT Viewer 控制台输出 (Qt Creator 'Application Output')")
+    print("   关键日志:")
+    print("   - 'readyRead() called' → socket 信号正常触发")
+    print("   - 'FAIL locking indexer' → indexer 锁冲突!")
+    print("   - 'condition FAIL' → socket/connected 匹配失败!")
+    print("   - 'read() TCP/TCP_SERVER' → 数据读取正常")
+    print("   - 'autoReconnect timeout' → 超时断开 (取消勾选 Auto Reconnect)")
+    print()
+    print("2. 检查 Viewer 状态栏:")
+    print("   - 'Recv:' 值是否 > 0 ?")
+    print("   - 表格中是否有消息 ?")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ecudialog.cpp
+++ b/src/ecudialog.cpp
@@ -178,6 +178,9 @@ unsigned int EcuDialog::port()
       case EcuItem::INTERFACETYPE_UDP:
            return  ui->comboBoxPortIP_UDP->currentText().toUInt();
            break;
+      case EcuItem::INTERFACETYPE_TCP_SERVER:
+           return  ui->comboBoxPortIP->currentText().toUInt();
+           break;
      default:
         break;
     }
@@ -416,6 +419,17 @@ void EcuDialog::on_comboBoxInterface_currentIndexChanged(int index)
             ui->checkBoxSendSerialHeaderSerial->setVisible(false);
             ui->checkBoxSyncToSerialHeaderSerial->setVisible(false);
             break;
+
+        case EcuItem::INTERFACETYPE_TCP_SERVER:
+            //we have TCP Server set -> disable serial, enable TCP tab for listen config
+            ui->tabWidget->setTabEnabled(1,true);
+            ui->tabWidget->setTabEnabled(2,false);
+            ui->tabWidget->setTabEnabled(3,false);
+            ui->comboBoxNetworkIF->setVisible(false);
+            ui->checkBoxMulticast->setVisible(false);
+            ui->label_3->setText(QString("Listen Address:"));
+            ui->label_3->setToolTip(QString("Local IP address to listen on.\nUse 0.0.0.0 or leave empty to listen on all interfaces."));
+        break;
 
     }
 }

--- a/src/ecudialog.ui
+++ b/src/ecudialog.ui
@@ -70,6 +70,11 @@
            <string>Serial ASCII</string>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>TCP Server DLT</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="9" column="0" colspan="3">

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 
 /* Custom message handler: writes qDebug to a log file for debugging */
 static QFile s_logFile;
+static QtMessageHandler s_defaultHandler = nullptr;
 void debugMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
     if (s_logFile.isOpen()) {
@@ -46,6 +47,9 @@ void debugMessageHandler(QtMsgType type, const QMessageLogContext &context, cons
         s_logFile.write(txt.toUtf8());
         s_logFile.flush();
     }
+    /* forward to default handler so console output is preserved */
+    if (s_defaultHandler)
+        s_defaultHandler(type, context, msg);
 }
 
 int main(int argc, char *argv[])
@@ -77,7 +81,7 @@ int main(int argc, char *argv[])
         QString logPath = QCoreApplication::applicationDirPath() + "/debug_tcp_server.log";
         s_logFile.setFileName(logPath);
         if (s_logFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-            qInstallMessageHandler(debugMessageHandler);
+            s_defaultHandler = qInstallMessageHandler(debugMessageHandler);
             qDebug() << "Debug logging started ->" << logPath;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,10 +21,32 @@
 #include <QApplication>
 #include <QStyleFactory>
 #include <QThread>
+#include <QFile>
+#include <QDateTime>
+#include <QDebug>
 
 #include <qdltoptmanager.h>
 
 #include "mainwindow.h"
+
+/* Custom message handler: writes qDebug to a log file for debugging */
+static QFile s_logFile;
+void debugMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    if (s_logFile.isOpen()) {
+        QString txt = QDateTime::currentDateTime().toString("hh:mm:ss.zzz") + " ";
+        switch (type) {
+            case QtDebugMsg:    txt += "DBG "; break;
+            case QtInfoMsg:     txt += "INF "; break;
+            case QtWarningMsg:  txt += "WRN "; break;
+            case QtCriticalMsg: txt += "CRT "; break;
+            case QtFatalMsg:    txt += "FTL "; break;
+        }
+        txt += msg + "\n";
+        s_logFile.write(txt.toUtf8());
+        s_logFile.flush();
+    }
+}
 
 int main(int argc, char *argv[])
 {
@@ -49,6 +71,16 @@ int main(int argc, char *argv[])
     // Keep the UI responsive under heavy background processing.
     QThread::currentThread()->setPriority(QThread::HighestPriority);
     QDltOptManager::getInstance()->parse(a.arguments());
+
+    /* Install debug log file handler (only with --debug-log flag) */
+    if (a.arguments().contains("--debug-log")) {
+        QString logPath = QCoreApplication::applicationDirPath() + "/debug_tcp_server.log";
+        s_logFile.setFileName(logPath);
+        if (s_logFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            qInstallMessageHandler(debugMessageHandler);
+            qDebug() << "Debug logging started ->" << logPath;
+        }
+    }
 
     MainWindow w;
     w.show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -44,6 +44,7 @@
 #include <QSerialPortInfo>
 #include <QNetworkProxyFactory>
 #include <QNetworkInterface>
+#include <QTcpServer>
 #include <QSortFilterProxyModel>
 #include <QDesktopServices>
 #include <QProcess>
@@ -4126,6 +4127,28 @@ void MainWindow::disconnectECU(EcuItem *ecuitem)
             if (ecuitem->socket->state()!=QAbstractSocket::UnconnectedState)
                 ecuitem->socket->disconnectFromHost();
         }
+        else if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
+        {
+            /* TCP Server */
+            if(ecuitem->socket && ecuitem->socket != &ecuitem->tcpsocket &&
+               ecuitem->socket->state() != QAbstractSocket::UnconnectedState)
+            {
+                disconnect(ecuitem->socket, nullptr, nullptr, nullptr);
+                ecuitem->socket->disconnectFromHost();
+                ecuitem->socket->deleteLater();
+            }
+            ecuitem->socket = &ecuitem->tcpsocket; /* restore default socket pointer */
+
+            if(ecuitem->tcpServer)
+            {
+                if(ecuitem->tcpServer->isListening())
+                    ecuitem->tcpServer->close();
+                disconnect(ecuitem->tcpServer, nullptr, nullptr, nullptr);
+                delete ecuitem->tcpServer;
+                ecuitem->tcpServer = nullptr;
+            }
+            qDebug() << "TCP Server stopped";
+        }
         else
         {
             /* Serial */
@@ -4327,6 +4350,51 @@ void MainWindow::connectECU(EcuItem* ecuitem,bool force)
                 }
             }
         }
+        else if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
+        {
+            /* TCP Server - listen for incoming connections */
+            qDebug()<< "Starting TCP Server on" << ecuitem->getHostname() << ":" << ecuitem->getIpport()
+                    << QDateTime::currentDateTime().toString("hh:mm:ss");
+
+            if (!ecuitem->tcpServer)
+            {
+                ecuitem->tcpServer = new QTcpServer();
+            }
+
+            /* connect newConnection signal */
+            disconnect(ecuitem->tcpServer, nullptr, nullptr, nullptr);
+            connect(ecuitem->tcpServer, &QTcpServer::newConnection,
+                    this, &MainWindow::newTcpConnection);
+
+            /* determine listen address */
+            QHostAddress listenAddr;
+            if (ecuitem->getHostname().isEmpty() || ecuitem->getHostname() == "0.0.0.0")
+            {
+                listenAddr = QHostAddress::Any;
+            }
+            else
+            {
+                listenAddr = QHostAddress(ecuitem->getHostname());
+            }
+
+            if (ecuitem->tcpServer->listen(listenAddr, ecuitem->getIpport()))
+            {
+                qDebug() << "TCP Server listening on" << listenAddr << ":" << ecuitem->getIpport();
+                /* TCP Server receives raw DLT streams with DLS\x01 serial header */
+                ecuitem->ipcon.setSyncSerialHeader(true);
+                /* TCP Server is a passive listener - no need for reconnect loop */
+                ecuitem->tryToConnect = false;
+                ecuitem->updateAutoReconnectTimestamp();
+                ecuitem->update();
+            }
+            else
+            {
+                qDebug() << "TCP Server failed to listen:" << ecuitem->tcpServer->errorString();
+                ecuitem->connectError = ecuitem->tcpServer->errorString();
+                ecuitem->connected = false;
+                ecuitem->update();
+            }
+        }
         else
         {
             /* Serial */
@@ -4480,7 +4548,7 @@ void MainWindow::disconnected()
     {
         EcuItem *ecuitem = (EcuItem*)project.ecu->topLevelItem(num);
         if( ecuitem &&
-            (ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP) &&
+            (ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER) &&
             ecuitem->socket == sender())
         {
             switch (ecuitem->interfacetype)
@@ -4490,6 +4558,13 @@ void MainWindow::disconnected()
                     break;
                case EcuItem::INTERFACETYPE_UDP:
                     qDebug() << "UDP socket closed on" << ecuitem->getEthIF() << "at" << QDateTime::currentDateTime().toString("hh:mm:ss") << GetConnectionType(ecuitem->interfacetype);
+                    break;
+               case EcuItem::INTERFACETYPE_TCP_SERVER:
+                    qDebug() << "TCP Server client disconnected at" << QDateTime::currentDateTime().toString("hh:mm:ss");
+                    /* restore default socket pointer after client disconnects */
+                    disconnect(ecuitem->socket, nullptr, nullptr, nullptr);
+                    ecuitem->socket->deleteLater();
+                    ecuitem->socket = &ecuitem->tcpsocket;
                     break;
                default:
                     break;
@@ -4502,8 +4577,9 @@ void MainWindow::disconnected()
             ecuitem->update();
             on_configWidget_itemSelectionChanged();
 
-            /* disconnect socket signals from window slots */
-            disconnect(ecuitem->socket,0,0,0);
+            /* disconnect socket signals from window slots (only for non-TCP_SERVER, already done above) */
+            if(ecuitem->interfacetype != EcuItem::INTERFACETYPE_TCP_SERVER)
+                disconnect(ecuitem->socket,0,0,0);
         }
     }
     checkConnectionState();
@@ -4537,6 +4613,26 @@ void MainWindow::timeout()
                     ecuitem->tryToConnect = true;
                     ecuitem->connected = false;
                 }
+                else if((ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
+                        && ecuitem->autoReconnect && ecuitem->connected != 0
+                        && ecuitem->totalBytesRcvd == static_cast<unsigned long>(ecuitem->totalBytesRcvdLastTimeout))
+                {
+                    qDebug() << "TCP Server client idle timeout for" << ecuitem->getHostname()
+                             << "totalBytesRcvd=" << ecuitem->totalBytesRcvd
+                             << "lastTimeout=" << ecuitem->totalBytesRcvdLastTimeout;
+                    /* Only disconnect the client, keep server listening */
+                    if(ecuitem->socket && ecuitem->socket != &ecuitem->tcpsocket)
+                    {
+                        disconnect(ecuitem->socket, nullptr, nullptr, nullptr);
+                        ecuitem->socket->disconnectFromHost();
+                        ecuitem->socket->deleteLater();
+                    }
+                    ecuitem->socket = &ecuitem->tcpsocket;
+                    ecuitem->connected = false;
+                    ecuitem->totalBytesRcvd = 0;
+                    ecuitem->totalBytesRcvdLastTimeout = 0;
+                    ecuitem->update();
+                }
 
                 ecuitem->totalBytesRcvdLastTimeout = ecuitem->totalBytesRcvd;
                 dltIndexer->unlock();
@@ -4549,6 +4645,11 @@ void MainWindow::timeout()
                 {
                 qDebug() << "TCP reconnect timeout for" << ecuitem->getHostname();
                 connectECU(ecuitem,true);
+                }
+                else if( ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER )
+                {
+                    /* TCP Server is passive - no reconnect needed, just wait for client */
+                    ecuitem->tryToConnect = false;
                 }
                 else if( ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP )
                 {
@@ -4568,7 +4669,7 @@ void MainWindow::error(QAbstractSocket::SocketError /* socketError */)
     {
         EcuItem *ecuitem = (EcuItem*)project.ecu->topLevelItem(num);
         if( ecuitem &&
-            (ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP) &&
+            (ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER) &&
             ecuitem->socket == sender())
         {
             /* save error */
@@ -4587,10 +4688,87 @@ void MainWindow::error(QAbstractSocket::SocketError /* socketError */)
     }
 }
 
+void MainWindow::newTcpConnection()
+{
+    /* signal emitted when a new client connects to the TCP server */
+    QTcpServer *server = qobject_cast<QTcpServer*>(sender());
+    if (!server)
+        return;
+
+    for(int num = 0; num < project.ecu->topLevelItemCount(); num++)
+    {
+        EcuItem *ecuitem = (EcuItem*)project.ecu->topLevelItem(num);
+        if(ecuitem && ecuitem->tcpServer == server)
+        {
+            if(ecuitem->connected)
+            {
+                /* already have a client connected, reject new connection (single client only) */
+                QTcpSocket *rejected = server->nextPendingConnection();
+                if (rejected)
+                {
+                    qDebug() << "TCP Server: rejecting additional connection from"
+                             << rejected->peerAddress().toString();
+                    rejected->abort();
+                    rejected->deleteLater();
+                }
+                return;
+            }
+
+            QTcpSocket *clientSocket = server->nextPendingConnection();
+            if (!clientSocket)
+                return;
+
+            qDebug() << "TCP Server: new connection from"
+                     << clientSocket->peerAddress().toString()
+                     << ":" << clientSocket->peerPort()
+                     << "interfacetype=" << ecuitem->interfacetype
+                     << "socket ptr=" << (void*)clientSocket;
+
+            /* use the accepted socket as the active socket for this ECU */
+            ecuitem->socket = clientSocket;
+            qDebug() << "newTcpConnection: ecuitem->socket SET to" << (void*)ecuitem->socket << "ecuitem=" << ecuitem->id << "ecuitem_ptr=" << (void*)ecuitem;
+
+            /* connect socket signals with window slots */
+            connect(clientSocket, SIGNAL(disconnected()), this, SLOT(disconnected()));
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+            connect(clientSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(error(QAbstractSocket::SocketError)));
+#else
+            connect(clientSocket, &QAbstractSocket::errorOccurred, this, &MainWindow::error);
+#endif
+            connect(clientSocket, SIGNAL(readyRead()), this, SLOT(readyRead()));
+            connect(clientSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this, SLOT(stateChangedIP(QAbstractSocket::SocketState)));
+
+            /* update connection state */
+            ecuitem->connected = true;
+            ecuitem->connectError.clear();
+            ecuitem->totalBytesRcvd = 0;
+            ecuitem->totalBytesRcvdLastTimeout = 0;
+            ecuitem->ipcon.clear();
+            ecuitem->update();
+            on_configWidget_itemSelectionChanged();
+            qDebug() << "newTcpConn: after update(), socket=" << (void*)ecuitem->socket;
+
+            /* send initial updates if configured */
+            if (ecuitem->updateDataIfOnline)
+            {
+                sendUpdates(ecuitem);
+            }
+            qDebug() << "newTcpConn: after sendUpdates(), socket=" << (void*)ecuitem->socket;
+
+            pluginManager.stateChanged(num, QDltConnection::QDltConnectionOnline,
+                                       clientSocket->peerAddress().toString());
+            qDebug() << "newTcpConn: after pluginManager.stateChanged(), socket=" << (void*)ecuitem->socket;
+            checkConnectionState();
+            qDebug() << "newTcpConn: after checkConnectionState(), socket=" << (void*)ecuitem->socket;
+            return;
+        }
+    }
+}
+
 void MainWindow::readyRead()
 {
     /* signal emited when socket received data */
-    //qDebug() << "readyRead" << __LINE__ << __FILE__;
+    qDebug() << "readyRead() called, sender:" << sender() << "at" << QTime::currentTime().toString("hh:mm:ss.zzz");
     /* Delay reading, if indexer is working on the dlt file */
     if(true == dltIndexer->tryLock())
     {
@@ -4600,18 +4778,25 @@ void MainWindow::readyRead()
             EcuItem *ecuitem = (EcuItem*)project.ecu->topLevelItem(num);
             if( ecuitem && (ecuitem->socket == sender() || ecuitem->m_serialport == sender() || dltIndexer == sender() ) && ( true == ecuitem->connected || (ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP ) ) )
             {
+                qDebug() << "readyRead() -> calling read() for ECU" << ecuitem->id << "interfacetype=" << ecuitem->interfacetype;
                 read(ecuitem);
+            }
+            else if(ecuitem)
+            {
+                qDebug() << "readyRead() condition FAIL: ecuitem->socket=" << (void*)ecuitem->socket
+                         << "sender()=" << (void*)sender()
+                         << "serialport=" << (void*)ecuitem->m_serialport
+                         << "connected=" << ecuitem->connected
+                         << "interfacetype=" << ecuitem->interfacetype
+                         << "ecuitem_ptr=" << (void*)ecuitem;
             }
         }
         dltIndexer->unlock();
     }
-    /*
     else
     {
-      qDebug() << "Fail locking indexer in readyRead" << __LINE__ << __FILE__;
-      //tbd: have a look why this one is called in commandline / mode File open
+      qDebug() << "FAIL locking indexer in readyRead() at" << QTime::currentTime().toString("hh:mm:ss.zzz");
     }
-    */
 
 }
 
@@ -4686,9 +4871,11 @@ void MainWindow::read(EcuItem* ecuitem)
     switch (ecuitem->interfacetype)
      {
       case EcuItem::INTERFACETYPE_TCP:
-          /* TCP */
+      case EcuItem::INTERFACETYPE_TCP_SERVER:
+          /* TCP or TCP Server */
           data = ecuitem->socket->readAll();
           bytesRcvd = data.size();
+          qDebug() << "read() TCP/TCP_SERVER bytes=" << bytesRcvd << "totalBytesRcvd=" << ecuitem->totalBytesRcvd;
           //qDebug() << "bytes received" << bytesRcvd;
           ecuitem->ipcon.add(data);
           break;
@@ -4784,10 +4971,13 @@ void MainWindow::read(EcuItem* ecuitem)
     /* reading data; new data is added to the current buffer */
      ecuitem->totalBytesRcvd += bytesRcvd;
 
-     while(((ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP) && ecuitem->ipcon.parseDlt(qmsg,settings->supportDLTv2Decoding)) ||
+     int parseCount = 0;
+     while(((ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER) && ecuitem->ipcon.parseDlt(qmsg,settings->supportDLTv2Decoding)) ||
             (ecuitem->interfacetype == EcuItem::INTERFACETYPE_SERIAL_DLT && ecuitem->serialcon.parseDlt(qmsg,settings->supportDLTv2Decoding)) ||
             (ecuitem->interfacetype == EcuItem::INTERFACETYPE_SERIAL_ASCII && ecuitem->serialcon.parseAscii(qmsg)) )
         {
+            parseCount++;
+            qDebug() << "read() parsed message #" << parseCount << "type=" << qmsg.getType() << "subtype=" << qmsg.getSubtype() << "headerSize=" << qmsg.getHeaderSize() << "payloadSize=" << qmsg.getPayloadSize();
             /* analyse received message, check if DLT control message response */
             if ( (qmsg.getType()==QDltMsg::DltTypeControl) && (qmsg.getSubtype()==QDltMsg::DltControlResponse))
             {
@@ -4826,7 +5016,10 @@ void MainWindow::read(EcuItem* ecuitem)
 
         } //end while
 
-     if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP)
+     if(parseCount > 0)
+         qDebug() << "read() total parsed:" << parseCount << "bytesError=" << ecuitem->ipcon.bytesError << "syncFound=" << ecuitem->ipcon.syncFound;
+
+     if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
         {
             /* TCP or UDP */
             totalByteErrorsRcvd+=ecuitem->ipcon.bytesError;
@@ -5227,7 +5420,7 @@ void MainWindow::controlMessage_SendControlMessage(EcuItem* ecuitem,DltMessage &
     msg.standardheader->len = DLT_HTOBE_16(msg.headersize - sizeof(DltStorageHeader) + msg.datasize);
 
     /* send message to daemon */
-    if ((ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP) && ecuitem->socket->isOpen())
+    if ((ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER) && ecuitem->socket->isOpen())
     {
         QByteArray tmpBuf;
 
@@ -8706,6 +8899,9 @@ QString MainWindow::GetConnectionType(int iTypeNumber)
        break;
    case EcuItem::INTERFACETYPE_SERIAL_ASCII:
        port=QString("Serial ASCII");
+       break;
+   case EcuItem::INTERFACETYPE_TCP_SERVER:
+       port=QString("TCP Server");
        break;
    default:
        port=QString("UNDEFINED");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4111,7 +4111,38 @@ void MainWindow::disconnectAll()
 
 void MainWindow::disconnectECU(EcuItem *ecuitem)
 {
-    if( true == ecuitem->tryToConnect )
+    if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
+    {
+        /* TCP Server cleanup must run regardless of tryToConnect */
+        ecuitem->tryToConnect = false;
+        ecuitem->connected = false;
+        ecuitem->connectError.clear();
+
+        /* clean up connected client socket synchronously (avoid double-free with parent delete) */
+        if(ecuitem->socket && ecuitem->socket != &ecuitem->tcpsocket)
+        {
+            disconnect(ecuitem->socket, nullptr, nullptr, nullptr);
+            ecuitem->socket->abort();
+            delete ecuitem->socket;
+        }
+        ecuitem->socket = &ecuitem->tcpsocket; /* restore default socket pointer */
+
+        /* stop and delete TCP server */
+        if(ecuitem->tcpServer)
+        {
+            if(ecuitem->tcpServer->isListening())
+                ecuitem->tcpServer->close();
+            disconnect(ecuitem->tcpServer, nullptr, nullptr, nullptr);
+            delete ecuitem->tcpServer;
+            ecuitem->tcpServer = nullptr;
+        }
+        qDebug() << "TCP Server stopped";
+
+        ecuitem->update();
+        on_configWidget_itemSelectionChanged();
+        ecuitem->InvalidAll();
+    }
+    else if( true == ecuitem->tryToConnect )
     {
         /* disconnect from host */
         ecuitem->tryToConnect = false;
@@ -4126,28 +4157,6 @@ void MainWindow::disconnectECU(EcuItem *ecuitem)
             /* TCP or UDP */
             if (ecuitem->socket->state()!=QAbstractSocket::UnconnectedState)
                 ecuitem->socket->disconnectFromHost();
-        }
-        else if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
-        {
-            /* TCP Server */
-            if(ecuitem->socket && ecuitem->socket != &ecuitem->tcpsocket &&
-               ecuitem->socket->state() != QAbstractSocket::UnconnectedState)
-            {
-                disconnect(ecuitem->socket, nullptr, nullptr, nullptr);
-                ecuitem->socket->disconnectFromHost();
-                ecuitem->socket->deleteLater();
-            }
-            ecuitem->socket = &ecuitem->tcpsocket; /* restore default socket pointer */
-
-            if(ecuitem->tcpServer)
-            {
-                if(ecuitem->tcpServer->isListening())
-                    ecuitem->tcpServer->close();
-                disconnect(ecuitem->tcpServer, nullptr, nullptr, nullptr);
-                delete ecuitem->tcpServer;
-                ecuitem->tcpServer = nullptr;
-            }
-            qDebug() << "TCP Server stopped";
         }
         else
         {
@@ -4675,8 +4684,20 @@ void MainWindow::error(QAbstractSocket::SocketError /* socketError */)
             /* save error */
             ecuitem->connectError = ecuitem->socket->errorString();
             qDebug() << "Socket connection error" << ecuitem->socket->errorString() << "for" << ecuitem->getHostname() << "on" << ecuitem->getIpport();// << __LINE__ << __FILE__;
-            /* disconnect socket */
-            ecuitem->socket->disconnectFromHost();
+
+            if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
+            {
+                /* TCP Server: clean up client socket BEFORE update() resets the pointer */
+                disconnect(ecuitem->socket, nullptr, nullptr, nullptr);
+                ecuitem->socket->abort();
+                ecuitem->socket->deleteLater();
+                ecuitem->socket = &ecuitem->tcpsocket;
+            }
+            else
+            {
+                /* TCP or UDP client */
+                ecuitem->socket->disconnectFromHost();
+            }
 
             /* update connection state */
             ecuitem->connected = false;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4789,7 +4789,9 @@ void MainWindow::newTcpConnection()
 void MainWindow::readyRead()
 {
     /* signal emited when socket received data */
-    qDebug() << "readyRead() called, sender:" << sender() << "at" << QTime::currentTime().toString("hh:mm:ss.zzz");
+    #ifdef QT_DEBUG
+        qDebug() << "readyRead() called, sender:" << sender() << "at" << QTime::currentTime().toString("hh:mm:ss.zzz");
+    #endif
     /* Delay reading, if indexer is working on the dlt file */
     if(true == dltIndexer->tryLock())
     {
@@ -4799,17 +4801,21 @@ void MainWindow::readyRead()
             EcuItem *ecuitem = (EcuItem*)project.ecu->topLevelItem(num);
             if( ecuitem && (ecuitem->socket == sender() || ecuitem->m_serialport == sender() || dltIndexer == sender() ) && ( true == ecuitem->connected || (ecuitem->interfacetype == EcuItem::INTERFACETYPE_UDP ) ) )
             {
+                #ifdef QT_DEBUG
                 qDebug() << "readyRead() -> calling read() for ECU" << ecuitem->id << "interfacetype=" << ecuitem->interfacetype;
+#endif
                 read(ecuitem);
             }
             else if(ecuitem)
             {
+                #ifdef QT_DEBUG
                 qDebug() << "readyRead() condition FAIL: ecuitem->socket=" << (void*)ecuitem->socket
                          << "sender()=" << (void*)sender()
                          << "serialport=" << (void*)ecuitem->m_serialport
                          << "connected=" << ecuitem->connected
                          << "interfacetype=" << ecuitem->interfacetype
                          << "ecuitem_ptr=" << (void*)ecuitem;
+#endif
             }
         }
         dltIndexer->unlock();
@@ -4896,7 +4902,9 @@ void MainWindow::read(EcuItem* ecuitem)
           /* TCP or TCP Server */
           data = ecuitem->socket->readAll();
           bytesRcvd = data.size();
+          #ifdef QT_DEBUG
           qDebug() << "read() TCP/TCP_SERVER bytes=" << bytesRcvd << "totalBytesRcvd=" << ecuitem->totalBytesRcvd;
+          #endif
           //qDebug() << "bytes received" << bytesRcvd;
           ecuitem->ipcon.add(data);
           break;
@@ -4998,7 +5006,9 @@ void MainWindow::read(EcuItem* ecuitem)
             (ecuitem->interfacetype == EcuItem::INTERFACETYPE_SERIAL_ASCII && ecuitem->serialcon.parseAscii(qmsg)) )
         {
             parseCount++;
+            #ifdef QT_DEBUG
             qDebug() << "read() parsed message #" << parseCount << "type=" << qmsg.getType() << "subtype=" << qmsg.getSubtype() << "headerSize=" << qmsg.getHeaderSize() << "payloadSize=" << qmsg.getPayloadSize();
+            #endif
             /* analyse received message, check if DLT control message response */
             if ( (qmsg.getType()==QDltMsg::DltTypeControl) && (qmsg.getSubtype()==QDltMsg::DltControlResponse))
             {
@@ -5037,8 +5047,10 @@ void MainWindow::read(EcuItem* ecuitem)
 
         } //end while
 
+     #ifdef QT_DEBUG
      if(parseCount > 0)
          qDebug() << "read() total parsed:" << parseCount << "bytesError=" << ecuitem->ipcon.bytesError << "syncFound=" << ecuitem->ipcon.syncFound;
+#endif
 
      if(ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP || ecuitem->interfacetype == EcuItem::INTERFACETYPE_TCP_SERVER)
         {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -586,6 +586,7 @@ private slots:
     void disconnected();
     void error(QAbstractSocket::SocketError);
     void readyRead();
+    void newTcpConnection();
     void timeout();
     void connectAll();
     void disconnectAll();

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -77,21 +77,22 @@ EcuItem::EcuItem(QTreeWidgetItem *parent)
     autoReconnectTimestamp = QDateTime::currentDateTime();
 
     writeDLTv2StorageHeader = false;
+
+    tcpServer = nullptr;
 }
 
 EcuItem::~EcuItem()
 {
-
+    delete tcpServer;
 }
 
 void EcuItem::update()
 {
-    if( ( true == tryToConnect ) && ( true == connected ))
+    if( connected )
     {
         setData(0,Qt::DisplayRole,id + " online");
         setForeground(0,QBrush(QColor(Qt::black)));
         setBackground(0,QBrush(QColor(Qt::green)));
-        //qDebug() << "green";
     }
     else if( ( true == tryToConnect )  && ( false == connected ))
     {
@@ -150,6 +151,12 @@ void EcuItem::update()
         case EcuItem::INTERFACETYPE_SERIAL_ASCII:
             setData(1,Qt::DisplayRole,QString("%1 [%2]").arg(description).arg(port));
             socket = 0;
+            break;
+        case EcuItem::INTERFACETYPE_TCP_SERVER:
+            setData(1,Qt::DisplayRole,QString("%1 [TCP Server %2:%3]").arg(description).arg(hostname).arg(ipport));
+            /* only reset socket to default if no client is connected */
+            if (!connected)
+                socket = &tcpsocket;
             break;
     }
 

--- a/src/project.h
+++ b/src/project.h
@@ -30,6 +30,7 @@
 #include <QTreeWidget>
 #include <QDockWidget>
 #include <QTcpSocket>
+#include <QTcpServer>
 #include <QUdpSocket>
 #include <QObject>
 #include <QDateTime>
@@ -51,7 +52,8 @@ public:
         INTERFACETYPE_TCP,
         INTERFACETYPE_UDP,
         INTERFACETYPE_SERIAL_DLT,
-        INTERFACETYPE_SERIAL_ASCII
+        INTERFACETYPE_SERIAL_ASCII,
+        INTERFACETYPE_TCP_SERVER
     };
 
     EcuItem(QTreeWidgetItem *parent = 0);
@@ -81,6 +83,9 @@ public:
     QTcpSocket tcpsocket;
     QUdpSocket udpsocket;
     QAbstractSocket * socket;
+
+    /* TCP Server */
+    QTcpServer *tcpServer = nullptr;
 
     QSerialPort *m_serialport;
 


### PR DESCRIPTION
## Summary

This PR adds a new **TCP Server** connection mode to DLT Viewer, allowing it to passively listen for incoming TCP connections from external DLT clients (e.g., ECU simulators, log generators, test tools) instead of only acting as a TCP client that initiates connections.

This is useful in scenarios where the DLT data source needs to push data to the Viewer, or when the Viewer should act as a central log receiver.

## Changes

### New Connection Type: `TCP Server DLT`
- Added `INTERFACETYPE_TCP_SERVER` to `EcuItem::InterfaceType` enum
- ECU configuration dialog now shows "TCP Server DLT" as a selectable interface type
- When selected, the TCP tab is enabled with a "Listen Address" field (use `0.0.0.0` or leave empty to listen on all interfaces)

### TCP Server Lifecycle (`mainwindow.cpp`)
- **Connect**: Creates a `QTcpServer` and starts listening on the configured address/port. Enables serial header sync parsing (`DLS\x01`).
- **Accept**: New `newTcpConnection()` slot handles incoming client connections. Uses single-client model — additional connections are rejected.
- **Read**: `read()` and `readyRead()` flows now handle `INTERFACETYPE_TCP_SERVER` identically to `INTERFACETYPE_TCP`, sharing the same `ipcon` parser.
- **Disconnect**: On client disconnect, the accepted socket is cleaned up and the default socket pointer is restored. The server keeps listening for new connections.
- **Disconnect ECU**: Stops the TCP server, closes all sockets, and cleans up resources.
- **Timeout**: Supports idle timeout for connected clients (when Auto Reconnect is enabled). Server mode does not trigger reconnect attempts — it passively waits for the next client.
- **Control Messages**: `controlMessage_SendControlMessage()` now supports sending to TCP Server connections.

### ECU State Display (`project.cpp`)
- `EcuItem::update()` simplified: shows "online" status whenever `connected == true` (previously required `tryToConnect` as well, which is not applicable for server mode).
- Added display format for TCP Server: `"description [TCP Server host:port]"`
- Added `QTcpServer *tcpServer` member to `EcuItem` with proper lifecycle management.

### Debug Logging (`main.cpp`)
- Added optional file-based debug logging via `--debug-log` command-line flag
- Writes timestamped debug output to `debug_tcp_server.log` next to the executable

### Diagnostic Script (`diag_dlt.py`)
- Added a Python test script that constructs valid DLT messages with serial headers and sends them to a TCP Server instance for validation

## Testing

1. Build DLT Viewer and start it
2. Create a new ECU → set Interface to **TCP Server DLT** → configure listen address/port → Connect
3. ECU status should show "online" (listening)
4. Connect a TCP client and send DLT data (e.g., `python diag_dlt.py`)
5. Messages should appear in the Viewer table
6. Disconnect the client → Viewer should resume listening for new connections
7. Disconnect the ECU → TCP Server stops

## Files Changed

| File | Description |
|---|---|
| `src/project.h` | Added `INTERFACETYPE_TCP_SERVER` enum, `QTcpServer` member |
| `src/project.cpp` | ECU display update, socket/server lifecycle |
| `src/ecudialog.cpp` | UI handling for TCP Server selection |
| `src/ecudialog.ui` | Added "TCP Server DLT" combo box item |
| `src/mainwindow.h` | Added `newTcpConnection()` slot declaration |
| `src/mainwindow.cpp` | Server lifecycle, read/error/timeout integration |
| `src/main.cpp` | `--debug-log` file logging support |
| `diag_dlt.py` | Diagnostic test script for TCP Server validation |